### PR TITLE
Add Qt login interface

### DIFF
--- a/src/login_view.py
+++ b/src/login_view.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+from PyQt5 import QtWidgets, uic
+from PyQt5.QtCore import pyqtSignal
+
+class LoginView(QtWidgets.QWidget):
+    """Widget that handles user login."""
+
+    authenticated = pyqtSignal(str)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        ui_path = Path(__file__).resolve().parent / 'ui' / 'login.ui'
+        uic.loadUi(ui_path, self)
+
+        # Access widgets defined in the .ui file
+        self.user_input = self.findChild(QtWidgets.QLineEdit, 'usernameLineEdit')
+        self.pass_input = self.findChild(QtWidgets.QLineEdit, 'passwordLineEdit')
+        self.error_label = self.findChild(QtWidgets.QLabel, 'errorLabel')
+        self.login_button = self.findChild(QtWidgets.QPushButton, 'loginButton')
+
+        if self.login_button:
+            self.login_button.clicked.connect(self.handle_login)
+
+    def handle_login(self):
+        """Validate credentials and emit authenticated signal."""
+        username = self.user_input.text() if self.user_input else ''
+        password = self.pass_input.text() if self.pass_input else ''
+
+        if not username or not password:
+            if self.error_label:
+                self.error_label.setText('Usuario y contraseña son obligatorios.')
+            return
+
+        if self.error_label:
+            self.error_label.clear()
+
+        # Here would normally be authentication logic with backend
+        # For now we assume success when fields are not empty
+        self.authenticated.emit(username)

--- a/src/ui/login.ui
+++ b/src/ui/login.ui
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>LoginWidget</class>
+ <widget class="QWidget" name="LoginWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>300</width>
+    <height>200</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="text">
+      <string>Sistema de Alquiler</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="usernameLineEdit">
+     <property name="placeholderText">
+      <string>Usuario</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="passwordLineEdit">
+     <property name="echoMode">
+      <enum>QLineEdit::Password</enum>
+     </property>
+     <property name="placeholderText">
+      <string>Contraseña</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="loginButton">
+     <property name="text">
+      <string>Ingresar</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="errorLabel">
+     <property name="text">
+      <string></string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">color: red;</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
## Summary
- create Qt Designer file for a login screen
- add `LoginView` class to load the UI, validate input, and emit a signal

## Testing
- `python -m py_compile src/login_view.py`

------
https://chatgpt.com/codex/tasks/task_e_685cb5869ae0832bb663ff72018067e0