### PR TITLE
Add main view UI and logic

### DIFF
--- a/src/views/main_view.py
+++ b/src/views/main_view.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from PyQt5 import QtWidgets, uic
+from PyQt5.QtCore import pyqtSignal
+
+
+class MainView(QtWidgets.QMainWindow):
+    """Main application window handling role based menus and logout."""
+
+    logged_out = pyqtSignal()
+
+    def __init__(self, username: str, role: str, parent=None):
+        super().__init__(parent)
+        ui_path = Path(__file__).resolve().parents[2] / 'ui' / 'main_window.ui'
+        uic.loadUi(ui_path, self)
+
+        self._username = username
+        self._role = role
+
+        # Setup status bar information
+        if self.statusBar():
+            self.statusBar().showMessage(f"Usuario: {username} | Rol: {role}")
+
+        # Access menus
+        self.menu_reservas = self.findChild(QtWidgets.QMenu, 'menuReservas')
+        self.menu_clientes = self.findChild(QtWidgets.QMenu, 'menuClientes')
+        self.menu_vehiculos = self.findChild(QtWidgets.QMenu, 'menuVehiculos')
+        self.menu_admin = self.findChild(QtWidgets.QMenu, 'menuAdministracion')
+
+        # Add logout action under Administración
+        self.logout_action = QtWidgets.QAction('Cerrar sesión', self)
+        if self.menu_admin:
+            self.menu_admin.addAction(self.logout_action)
+        else:
+            self.menuBar().addAction(self.logout_action)
+        self.logout_action.triggered.connect(self.logout)
+
+        self._apply_role_visibility(role)
+
+    def _apply_role_visibility(self, role: str):
+        """Show or hide menus depending on the user role."""
+        if self.menu_admin:
+            self.menu_admin.menuAction().setVisible(role.lower() == 'admin')
+
+    def logout(self):
+        """Emit logout signal and close the window."""
+        self.logged_out.emit()
+        self.close()

--- a/ui/main_window.ui
+++ b/ui/main_window.ui
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QStackedWidget" name="stackedWidget"/>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QMenuBar" name="menubar">
+   <addaction name="menuReservas"/>
+   <addaction name="menuClientes"/>
+   <addaction name="menuVehiculos"/>
+   <addaction name="menuAdministracion"/>
+  </widget>
+  <widget class="QStatusBar" name="statusbar"/>
+ </widget>
+ <action name="menuReservas">
+  <property name="text">
+   <string>Reservas</string>
+  </property>
+ </action>
+ <action name="menuClientes">
+  <property name="text">
+   <string>Clientes</string>
+  </property>
+ </action>
+ <action name="menuVehiculos">
+  <property name="text">
+   <string>Vehículos</string>
+  </property>
+ </action>
+ <action name="menuAdministracion">
+  <property name="text">
+   <string>Administración</string>
+  </property>
+ </action>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
## Summary
- design `main_window.ui` with menu bar, status bar, and stacked widget
- implement `MainView` class to load UI, show options based on role and handle logout

## Testing
- `python -m py_compile src/views/main_view.py src/views/login_view.py`

------
https://chatgpt.com/codex/tasks/task_e_685cc0ea7ea8832b8f9bbe1fcf65af98