### PR TITLE
Improve login error handling

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -20,6 +20,10 @@ class AuthManager:
 
         result = self.db.execute_query(query, (usuario, hashed_pwd))
 
+        # Si la consulta devuelve None, hubo un problema de base de datos
+        if result is None:
+            raise ConnectionError("Error executing login query")
+
         if result and len(result) > 0:
             # Convertir resultado en diccionario
             row = result[0]

--- a/src/views/login_view.py
+++ b/src/views/login_view.py
@@ -33,8 +33,16 @@ class LoginView(QDialog):
             QMessageBox.warning(self, "Error", "Por favor complete todos los campos")
             return
             
-        user_data = self.auth_manager.login(usuario, contrasena)
-        
+        try:
+            user_data = self.auth_manager.login(usuario, contrasena)
+        except Exception:
+            QMessageBox.critical(
+                self,
+                "Error de base de datos",
+                "Ocurri\u00f3 un problema al conectar con la base de datos."
+            )
+            return
+
         if user_data:
             self.user_data = user_data
             self.accept()


### PR DESCRIPTION
## Summary
- raise `ConnectionError` in `AuthManager.login` when a DB error occurs
- show a critical dialog in `LoginView.attempt_login` if login query fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cd0ba97e0832b9fb3df9fdb6a6a6f