### PR TITLE
Add local SQLite storage for offline reservations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ fails the manager automatically falls back to a local SQLite database defined by
 will be set to `True` and all subsequent queries are executed on the local
 file. This allows the application to keep basic functionality when the remote
 server is unreachable.
+
+## Local offline storage
+
+When the application cannot reach the remote MariaDB server, reservations are now stored in the local SQLite database. The schema for this lightweight database lives in `data/sqlite_schema.sql` and creates the tables `Cliente`, `Reserva` and `Abono`. Each table includes a `pendiente` column used to mark records that still need to be synchronized with the remote server.

--- a/data/sqlite_schema.sql
+++ b/data/sqlite_schema.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS Cliente (
+    id_cliente INTEGER PRIMARY KEY AUTOINCREMENT,
+    documento TEXT,
+    nombre TEXT,
+    telefono TEXT,
+    pendiente INTEGER DEFAULT 1
+);
+
+CREATE TABLE IF NOT EXISTS Reserva (
+    id_reserva INTEGER PRIMARY KEY AUTOINCREMENT,
+    fecha_hora_salida TEXT,
+    fecha_hora_entrada TEXT,
+    id_vehiculo TEXT,
+    id_cliente INTEGER,
+    id_seguro INTEGER,
+    id_estado INTEGER,
+    pendiente INTEGER DEFAULT 1
+);
+
+CREATE TABLE IF NOT EXISTS Abono (
+    id_abono INTEGER PRIMARY KEY AUTOINCREMENT,
+    valor REAL,
+    fecha_hora TEXT,
+    id_reserva INTEGER,
+    pendiente INTEGER DEFAULT 1
+);

--- a/src/db_manager.py
+++ b/src/db_manager.py
@@ -61,25 +61,8 @@ class DBManager:
             return None
 
     def save_pending_reservation(self, data):
-        """Persist reservation data locally when the remote DB is unreachable."""
-        import json
-        from pathlib import Path
-
-        pending_file = Path(__file__).resolve().parents[1] / 'data' / 'pending_reservations.json'
-
-        reservations = []
-        if pending_file.exists():
-            with pending_file.open('r', encoding='utf-8') as fh:
-                try:
-                    reservations = json.load(fh)
-                except json.JSONDecodeError:
-                    reservations = []
-
-        reservations.append(data)
-
-        pending_file.parent.mkdir(parents=True, exist_ok=True)
-        with pending_file.open('w', encoding='utf-8') as fh:
-            json.dump(reservations, fh, ensure_ascii=False, indent=2)
+        """Persist reservation data in the local SQLite database."""
+        self._sqlite.save_pending_reservation(data)
 
     def close(self):
         """Placeholder to keep API compatibility."""

--- a/src/sqlite_manager.py
+++ b/src/sqlite_manager.py
@@ -1,5 +1,6 @@
 import os
 import sqlite3
+from pathlib import Path
 from dotenv import load_dotenv
 
 
@@ -9,6 +10,17 @@ class SQLiteManager:
     def __init__(self):
         load_dotenv()
         self.db_path = os.getenv("LOCAL_DB_PATH", "local.db")
+        self._initialize_db()
+
+    def _initialize_db(self):
+        """Ensure required tables exist."""
+        schema = Path(__file__).resolve().parents[1] / 'data' / 'sqlite_schema.sql'
+        if not schema.exists():
+            return
+        conn = sqlite3.connect(self.db_path)
+        with schema.open('r', encoding='utf-8') as fh:
+            conn.executescript(fh.read())
+        conn.close()
 
     def connect(self):
         try:
@@ -39,22 +51,20 @@ class SQLiteManager:
             return None
 
     def save_pending_reservation(self, data):
-        """Persist reservation data locally."""
-        import json
-        from pathlib import Path
-
-        pending_file = Path(__file__).resolve().parents[1] / 'data' / 'pending_reservations.json'
-
-        reservations = []
-        if pending_file.exists():
-            with pending_file.open('r', encoding='utf-8') as fh:
-                try:
-                    reservations = json.load(fh)
-                except json.JSONDecodeError:
-                    reservations = []
-
-        reservations.append(data)
-        pending_file.parent.mkdir(parents=True, exist_ok=True)
-        with pending_file.open('w', encoding='utf-8') as fh:
-            json.dump(reservations, fh, ensure_ascii=False, indent=2)
+        """Insert a reservation locally marked as pending."""
+        query = (
+            "INSERT INTO Reserva "
+            "(fecha_hora_salida, fecha_hora_entrada, id_vehiculo, "
+            "id_cliente, id_seguro, id_estado, pendiente) "
+            "VALUES (?, ?, ?, ?, ?, ?, 1)"
+        )
+        params = (
+            data.get("fecha_hora_salida"),
+            data.get("fecha_hora_entrada"),
+            data.get("id_vehiculo"),
+            data.get("id_cliente"),
+            data.get("id_seguro"),
+            data.get("id_estado"),
+        )
+        self.execute_query(query, params, fetch=False)
 


### PR DESCRIPTION
## Summary
- initialize SQLite tables from `data/sqlite_schema.sql`
- insert pending reservations into SQLite instead of JSON file
- simplify DBManager pending reservation logic
- document new offline storage mechanism

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ce79fe79c832b9d2825eefae45e31