### PR TITLE
Implement periodic sync of offline reservations

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ server is unreachable.
 ## Local offline storage
 
 When the application cannot reach the remote MariaDB server, reservations are now stored in the local SQLite database. The schema for this lightweight database lives in `data/sqlite_schema.sql` and creates the tables `Cliente`, `Reserva` and `Abono`. Each table includes a `pendiente` column used to mark records that still need to be synchronized with the remote server.
+
+## Sincronización automática
+
+`DBManager.sync_pending_reservations()` revisa periódicamente los registros
+pendientes en la base de datos local e intenta insertarlos en MariaDB. Cuando la
+operación tiene éxito dichos registros se eliminan de SQLite. Este proceso se
+ejecuta cada cinco minutos desde `MainView` usando un `QTimer`.

--- a/src/db_manager.py
+++ b/src/db_manager.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import pymysql
 from dotenv import load_dotenv
 
@@ -10,6 +11,8 @@ class DBManager:
 
     def __init__(self):
         load_dotenv()
+        logging.basicConfig(level=logging.INFO)
+        self.logger = logging.getLogger(__name__)
         self.offline = False
         self._sqlite = SQLiteManager()
 
@@ -63,6 +66,73 @@ class DBManager:
     def save_pending_reservation(self, data):
         """Persist reservation data in the local SQLite database."""
         self._sqlite.save_pending_reservation(data)
+
+    def sync_pending_reservations(self):
+        """Attempt to push locally stored reservations and payments to MariaDB."""
+        if self.offline:
+            self.logger.info("[DBManager] Sincronización omitida, modo sin conexión")
+            return
+
+        # Connect directly to MariaDB
+        config = {
+            'host': os.getenv('DB_REMOTE_HOST'),
+            'user': os.getenv('DB_REMOTE_USER'),
+            'password': os.getenv('DB_REMOTE_PASSWORD'),
+            'database': os.getenv('DB_REMOTE_NAME'),
+            'connect_timeout': 3,
+            'charset': 'utf8mb4',
+            'cursorclass': pymysql.cursors.Cursor,
+            'autocommit': True,
+        }
+        try:
+            conn = pymysql.connect(**config)
+        except Exception as exc:
+            self.logger.error(f"[DBManager] Error conectando a MariaDB: {exc}")
+            self.offline = True
+            return
+
+        cursor = conn.cursor()
+
+        # Synchronize reservations
+        reservas = self._sqlite.get_pending_reservations() or []
+        for res in reservas:
+            insert_q = (
+                "INSERT INTO Alquiler "
+                "(fecha_hora_salida, fecha_hora_entrada, id_vehiculo, "
+                "id_cliente, id_seguro, id_estado) "
+                "VALUES (%s, %s, %s, %s, %s, %s)"
+            )
+            params = (res[1], res[2], res[3], res[4], res[5], res[6])
+            try:
+                cursor.execute(insert_q, params)
+                self._sqlite.delete_reservation(res[0])
+                self.logger.info(f"[DBManager] Sincronizada reserva {res[0]}")
+            except Exception as exc:
+                self.logger.error(f"[DBManager] Error insertando reserva {res[0]}: {exc}")
+                conn.close()
+                return
+
+        # Synchronize payments (abonos)
+        abonos = self._sqlite.get_pending_abonos() or []
+        for ab in abonos:
+            insert_a = (
+                "INSERT INTO Abono_reserva "
+                "(valor, fecha_hora, id_reserva, id_medio_pago) "
+                "VALUES (%s, %s, %s, %s)"
+            )
+            params = (ab[1], ab[2], ab[3], 1)
+            try:
+                cursor.execute(insert_a, params)
+                self._sqlite.delete_abono(ab[0])
+                self.logger.info(f"[DBManager] Sincronizado abono {ab[0]}")
+            except Exception as exc:
+                self.logger.error(f"[DBManager] Error insertando abono {ab[0]}: {exc}")
+                conn.close()
+                return
+
+        cursor.close()
+        conn.close()
+        self.logger.info("[DBManager] Sincronización finalizada")
 
     def close(self):
         """Placeholder to keep API compatibility."""

--- a/src/sqlite_manager.py
+++ b/src/sqlite_manager.py
@@ -68,3 +68,30 @@ class SQLiteManager:
         )
         self.execute_query(query, params, fetch=False)
 
+    def get_pending_reservations(self):
+        """Return all reservations marked as pending."""
+        query = (
+            "SELECT id_reserva, fecha_hora_salida, fecha_hora_entrada, "
+            "id_vehiculo, id_cliente, id_seguro, id_estado "
+            "FROM Reserva WHERE pendiente = 1"
+        )
+        return self.execute_query(query)
+
+    def delete_reservation(self, reserva_id):
+        """Remove a reservation from the local database."""
+        query = "DELETE FROM Reserva WHERE id_reserva = ?"
+        self.execute_query(query, (reserva_id,), fetch=False)
+
+    def get_pending_abonos(self):
+        """Return all payments marked as pending."""
+        query = (
+            "SELECT id_abono, valor, fecha_hora, id_reserva "
+            "FROM Abono WHERE pendiente = 1"
+        )
+        return self.execute_query(query)
+
+    def delete_abono(self, abono_id):
+        """Remove a payment from the local database."""
+        query = "DELETE FROM Abono WHERE id_abono = ?"
+        self.execute_query(query, (abono_id,), fetch=False)
+

--- a/src/views/main_view.py
+++ b/src/views/main_view.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from PyQt5 import QtWidgets, uic
-from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtCore import pyqtSignal, QTimer
+
+from ..db_manager import DBManager
 
 
 class MainView(QtWidgets.QMainWindow):
@@ -15,6 +17,11 @@ class MainView(QtWidgets.QMainWindow):
 
         self._username = username
         self._role = role
+        self._db_manager = DBManager()
+
+        self._sync_timer = QTimer(self)
+        self._sync_timer.timeout.connect(self._db_manager.sync_pending_reservations)
+        self._sync_timer.start(5 * 60 * 1000)
 
         # Setup status bar information
         if self.statusBar():


### PR DESCRIPTION
## Summary
- extend SQLite manager with helpers to fetch and delete pending rows
- add `DBManager.sync_pending_reservations` to push offline data to MariaDB
- schedule automatic sync every five minutes from `MainView`
- document the new behaviour in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ce8465214832b90eb9eaf800cb06c