### PR TITLE
Add customer registration view and trigger

### DIFF
--- a/data/sql_bases-2.sql
+++ b/data/sql_bases-2.sql
@@ -358,3 +358,15 @@ CREATE TABLE Usuario (
   FOREIGN KEY (id_cliente) REFERENCES Cliente(id_cliente),
   FOREIGN KEY (id_empleado) REFERENCES Empleado(id_empleado)
 ) ENGINE=InnoDB;
+
+DELIMITER $$
+CREATE TRIGGER trg_cliente_usuario
+AFTER INSERT ON Cliente
+FOR EACH ROW
+BEGIN
+    DECLARE rid INT;
+    SELECT id_rol INTO rid FROM Rol WHERE nombre='cliente' LIMIT 1;
+    INSERT INTO Usuario (usuario, contrasena, id_rol, id_cliente)
+    VALUES (NEW.correo, SHA2(NEW.documento, 256), rid, NEW.id_cliente);
+END$$
+DELIMITER ;

--- a/data/sqlite_schema.sql
+++ b/data/sqlite_schema.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS Cliente (
     documento TEXT,
     nombre TEXT,
     telefono TEXT,
+    correo TEXT,
     pendiente INTEGER DEFAULT 1
 );
 
@@ -24,3 +25,19 @@ CREATE TABLE IF NOT EXISTS Abono (
     id_reserva INTEGER,
     pendiente INTEGER DEFAULT 1
 );
+
+CREATE TABLE IF NOT EXISTS Usuario (
+    id_usuario INTEGER PRIMARY KEY AUTOINCREMENT,
+    usuario TEXT,
+    contrasena TEXT,
+    id_rol INTEGER,
+    id_cliente INTEGER,
+    id_empleado INTEGER
+);
+
+CREATE TRIGGER IF NOT EXISTS trg_cliente_usuario
+AFTER INSERT ON Cliente
+BEGIN
+    INSERT INTO Usuario (usuario, contrasena, id_rol, id_cliente)
+    VALUES (NEW.correo, NEW.documento, 1, NEW.id_cliente);
+END;

--- a/src/views/login_view.py
+++ b/src/views/login_view.py
@@ -1,6 +1,14 @@
 import os
-from PyQt5.QtWidgets import QDialog, QMessageBox, QPushButton, QLineEdit, QLabel
+from PyQt5.QtWidgets import (
+    QDialog,
+    QMessageBox,
+    QPushButton,
+    QLineEdit,
+    QLabel,
+)
 from PyQt5.uic import loadUi
+
+from .registro_view import RegistroView
 
 class LoginView(QDialog):
     
@@ -17,12 +25,15 @@ class LoginView(QDialog):
         self.usernameLineEdit = self.findChild(QLineEdit, 'usernameLineEdit')
         self.passwordLineEdit = self.findChild(QLineEdit, 'passwordLineEdit')
         self.btn_login = self.findChild(QPushButton, 'btn_login')
+        self.btn_register = self.findChild(QPushButton, 'btn_register')
         
         self.auth_manager = auth_manager
         self.user_data = None
         
         # Conectar eventos
         self.btn_login.clicked.connect(self.attempt_login)
+        if self.btn_register:
+            self.btn_register.clicked.connect(self.open_registration)
         
     def attempt_login(self):
         usuario = self.usernameLineEdit.text().strip()
@@ -49,5 +60,5 @@ class LoginView(QDialog):
             QMessageBox.warning(self, "Error", "Credenciales incorrectas")
     
     def open_registration(self):
-        print("Funcionalidad de registro a implementar")
-        QMessageBox.information(self, "Registro", "Funcionalidad de registro en desarrollo")
+        registro = RegistroView(self.auth_manager.db)
+        registro.exec_()

--- a/src/views/registro_view.py
+++ b/src/views/registro_view.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+from PyQt5 import QtWidgets, uic
+from ..db_manager import DBManager
+
+
+class RegistroView(QtWidgets.QDialog):
+    """Formulario simple para registrar clientes."""
+
+    def __init__(self, db_manager: DBManager, parent=None):
+        super().__init__(parent)
+        ui_path = Path(__file__).resolve().parents[2] / 'ui' / 'registro.ui'
+        uic.loadUi(ui_path, self)
+
+        self.db_manager = db_manager
+
+        # Widgets
+        self.documento_edit = self.findChild(QtWidgets.QLineEdit, 'documentoLineEdit')
+        self.nombre_edit = self.findChild(QtWidgets.QLineEdit, 'nombreLineEdit')
+        self.telefono_edit = self.findChild(QtWidgets.QLineEdit, 'telefonoLineEdit')
+        self.correo_edit = self.findChild(QtWidgets.QLineEdit, 'correoLineEdit')
+        self.registrar_btn = self.findChild(QtWidgets.QPushButton, 'btn_registrar')
+
+        if self.registrar_btn:
+            self.registrar_btn.clicked.connect(self.registrar_cliente)
+
+    def registrar_cliente(self):
+        """Insertar un nuevo cliente después de validar los datos."""
+        documento = self.documento_edit.text().strip()
+        nombre = self.nombre_edit.text().strip()
+        telefono = self.telefono_edit.text().strip()
+        correo = self.correo_edit.text().strip()
+
+        if not documento or not nombre or not correo:
+            QtWidgets.QMessageBox.warning(self, 'Error', 'Complete todos los campos requeridos')
+            return
+
+        # Verificar unicidad del correo
+        count_q = 'SELECT COUNT(*) FROM Cliente WHERE correo = %s'
+        result = self.db_manager.execute_query(count_q, (correo,))
+        if result and result[0][0] > 0:
+            QtWidgets.QMessageBox.warning(self, 'Error', 'El correo ya está registrado')
+            return
+
+        insert_q = (
+            'INSERT INTO Cliente (documento, nombre, telefono, correo) '
+            'VALUES (%s, %s, %s, %s)'
+        )
+        params = (documento, nombre, telefono, correo)
+        try:
+            self.db_manager.execute_query(insert_q, params, fetch=False)
+            QtWidgets.QMessageBox.information(self, 'Éxito', 'Registro completado')
+            self.accept()
+        except Exception as exc:
+            QtWidgets.QMessageBox.critical(self, 'Error', f'No se pudo registrar: {exc}')
+

--- a/ui/login.ui
+++ b/ui/login.ui
@@ -46,6 +46,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QPushButton" name="btn_register">
+     <property name="text">
+      <string>Registrarse</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QLabel" name="errorLabel">
      <property name="text">
       <string></string>

--- a/ui/registro.ui
+++ b/ui/registro.ui
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>RegistroWidget</class>
+ <widget class="QWidget" name="RegistroWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>300</width>
+    <height>250</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="titleLabel">
+     <property name="text">
+      <string>Registro de Cliente</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="documentoLineEdit">
+     <property name="placeholderText">
+      <string>Documento</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="nombreLineEdit">
+     <property name="placeholderText">
+      <string>Nombre</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="telefonoLineEdit">
+     <property name="placeholderText">
+      <string>Teléfono</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="correoLineEdit">
+     <property name="placeholderText">
+      <string>Correo</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="btn_registrar">
+     <property name="text">
+      <string>Registrar</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
## Summary
- add `RegistroView` dialog to register new clients
- enable access to registration from `LoginView`
- append new trigger to MariaDB schema and extend SQLite schema
- update login UI with register button

## Testing
- `python -m py_compile src/views/registro_view.py src/views/login_view.py`

------
https://chatgpt.com/codex/tasks/task_e_685ce92460e0832bb6ae6b021bc81de7