### PR TITLE
Add logging and login lockout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,25 @@ When the application cannot reach the remote MariaDB server, reservations are no
 pendientes en la base de datos local e intenta insertarlos en MariaDB. Cuando la
 operación tiene éxito dichos registros se eliminan de SQLite. Este proceso se
 ejecuta cada cinco minutos desde `MainView` usando un `QTimer`.
+
+## Ejemplo de configuración de logs
+
+El proyecto utiliza el módulo `logging` para registrar accesos, errores y
+eventos de sincronización. Una configuración básica podría colocarse al inicio
+de la aplicación:
+
+```python
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    handlers=[
+        logging.FileHandler("app.log"),
+        logging.StreamHandler(),
+    ],
+)
+```
+
+Esto generará un archivo `app.log` con los eventos producidos por
+`AuthManager` y `DBManager`, además de mostrarlos por consola.

--- a/src/auth.py
+++ b/src/auth.py
@@ -1,11 +1,34 @@
 import hashlib
+import logging
+import time
+
+from .config import Config
 
 
 class AuthManager:
+    """Gestiona autenticación y bloqueo temporal de usuarios."""
+
     def __init__(self, db_manager):
         self.db = db_manager
+        self.logger = logging.getLogger(__name__)
+        self.failed_attempts = {}
+        self.blocked_users = {}
+
+    def _is_blocked(self, usuario):
+        """Return True if user is currently blocked."""
+        unblock_time = self.blocked_users.get(usuario)
+        if unblock_time and time.time() < unblock_time:
+            return True
+        if unblock_time:
+            # Bloqueo expirado
+            self.blocked_users.pop(usuario, None)
+        return False
 
     def login(self, usuario, contrasena):
+        if self._is_blocked(usuario):
+            self.logger.warning("Intento de acceso de usuario bloqueado: %s", usuario)
+            return None
+
         # Aplicar hash a la contraseña
         hashed_pwd = hashlib.sha256(contrasena.encode()).hexdigest()
         # Consultar base de datos
@@ -17,12 +40,17 @@ class AuthManager:
         WHERE u.usuario = %s AND u.contrasena = %s
         """
         result = self.db.execute_query(query, (usuario, hashed_pwd))
-        # Si la consulta devuelve None, hubo un problema de base de datos
+
         if result is None:
-            print("[AuthManager] Error ejecutando consulta de login")
+            self.logger.error("Error ejecutando consulta de login")
             raise ConnectionError("Error executing login query")
+
         if result and len(result) > 0:
             row = result[0]
+            self.logger.info("Usuario %s autenticado correctamente", usuario)
+            # Resetear intentos fallidos en caso de éxito
+            self.failed_attempts.pop(usuario, None)
+            self.blocked_users.pop(usuario, None)
             return {
                 'id_usuario': row[0],
                 'usuario': row[1],
@@ -30,4 +58,18 @@ class AuthManager:
                 'id_cliente': row[3],
                 'id_empleado': row[4]
             }
+        # Credenciales incorrectas
+        attempts = self.failed_attempts.get(usuario, 0) + 1
+        self.failed_attempts[usuario] = attempts
+        self.logger.warning(
+            "Intento fallido %s para el usuario %s", attempts, usuario
+        )
+        if attempts >= Config.MAX_LOGIN_ATTEMPTS:
+            self.blocked_users[usuario] = time.time() + Config.BLOCK_TIME
+            self.failed_attempts[usuario] = 0
+            self.logger.error(
+                "Usuario %s bloqueado temporalmente por %s segundos",
+                usuario,
+                Config.BLOCK_TIME,
+            )
         return None

--- a/src/config.py
+++ b/src/config.py
@@ -13,4 +13,6 @@ class Config:
 
     # Configuraci\u00f3n de seguridad
     MAX_LOGIN_ATTEMPTS = 3
+    # Tiempo de bloqueo en segundos cuando se supera el número de intentos
+    BLOCK_TIME = 300  # 5 minutos
     PASSWORD_HASH = "sha256"

--- a/src/db_manager.py
+++ b/src/db_manager.py
@@ -33,10 +33,10 @@ class DBManager:
         }
         try:
             connection = pymysql.connect(**config)
-            print("[DBManager] ¡Conexión exitosa a la base de datos!")
+            self.logger.info("Conexión exitosa a la base de datos")
             return connection
         except Exception as exc:
-            print(f"[DBManager] Error de conexión a la base de datos: {exc}")
+            self.logger.error("Error de conexión a la base de datos: %s", exc)
             self.offline = True
             return self._sqlite.connect()
 
@@ -44,7 +44,7 @@ class DBManager:
         try:
             conn = self.connect()
             if conn is None:
-                print("[DBManager] No se pudo establecer conexión con la base de datos")
+                self.logger.error("No se pudo establecer conexión con la base de datos")
                 return None
             cursor = conn.cursor()
             cursor.execute(query, params or ())
@@ -57,7 +57,7 @@ class DBManager:
             conn.close()
             return result
         except Exception as exc:
-            print(f"[DBManager] Error ejecutando consulta: {exc}")
+            self.logger.error("Error ejecutando consulta: %s", exc)
             if not self.offline:
                 self.offline = True
                 return self._sqlite.execute_query(query, params, fetch)
@@ -87,7 +87,7 @@ class DBManager:
         try:
             conn = pymysql.connect(**config)
         except Exception as exc:
-            self.logger.error(f"[DBManager] Error conectando a MariaDB: {exc}")
+            self.logger.error("[DBManager] Error conectando a MariaDB: %s", exc)
             self.offline = True
             return
 
@@ -106,9 +106,11 @@ class DBManager:
             try:
                 cursor.execute(insert_q, params)
                 self._sqlite.delete_reservation(res[0])
-                self.logger.info(f"[DBManager] Sincronizada reserva {res[0]}")
+                self.logger.info("[DBManager] Sincronizada reserva %s", res[0])
             except Exception as exc:
-                self.logger.error(f"[DBManager] Error insertando reserva {res[0]}: {exc}")
+                self.logger.error(
+                    "[DBManager] Error insertando reserva %s: %s", res[0], exc
+                )
                 conn.close()
                 return
 
@@ -124,9 +126,11 @@ class DBManager:
             try:
                 cursor.execute(insert_a, params)
                 self._sqlite.delete_abono(ab[0])
-                self.logger.info(f"[DBManager] Sincronizado abono {ab[0]}")
+                self.logger.info("[DBManager] Sincronizado abono %s", ab[0])
             except Exception as exc:
-                self.logger.error(f"[DBManager] Error insertando abono {ab[0]}: {exc}")
+                self.logger.error(
+                    "[DBManager] Error insertando abono %s: %s", ab[0], exc
+                )
                 conn.close()
                 return
 


### PR DESCRIPTION
## Summary
- add temporary user blocking logic to `AuthManager`
- use `logging` for DB access and synchronization events
- parameterize insert queries
- document logging configuration in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cea418808832b90670b1755f2a6d1