### PR TITLE
Handle offline password updates

### DIFF
--- a/data/sqlite_schema.sql
+++ b/data/sqlite_schema.sql
@@ -89,7 +89,8 @@ CREATE TABLE IF NOT EXISTS Usuario (
     contrasena TEXT,
     id_rol INTEGER,
     id_cliente INTEGER,
-    id_empleado INTEGER
+    id_empleado INTEGER,
+    pendiente INTEGER DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS Empleado (

--- a/src/sqlite_manager.py
+++ b/src/sqlite_manager.py
@@ -135,3 +135,13 @@ class SQLiteManager:
         query = "DELETE FROM Abono WHERE id_abono = ?"
         self.execute_query(query, (abono_id,), fetch=False)
 
+    def get_pending_password_updates(self):
+        """Return users whose password updates are pending."""
+        query = "SELECT usuario, contrasena FROM Usuario WHERE pendiente = 1"
+        return self.execute_query(query)
+
+    def clear_pending_password(self, usuario):
+        """Reset the pending flag for a user password update."""
+        query = "UPDATE Usuario SET pendiente = 0 WHERE usuario = ?"
+        self.execute_query(query, (usuario,), fetch=False)
+


### PR DESCRIPTION
## Summary
- add `pendiente` flag to `Usuario` in SQLite schema
- support getting/clearing pending password updates in `SQLiteManager`
- mark password changes as pending in offline mode
- sync user password updates when reconnecting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68640790ffec832b95d88e5c7782bf40