### PR TITLE
Centralize style constants

### DIFF
--- a/main.py
+++ b/main.py
@@ -53,63 +53,8 @@ from src.views.ctk_views import ClienteView
 from src.views.main_view import (
     GerenteViewQt, AdminViewQt, EmpleadoViewQt, EmpleadoVentasViewQt, EmpleadoMantenimientoViewQt, EmpleadoCajaViewQt
 )
+from src.styles import MODERN_QSS
 
-MODERN_QSS = """
-QMainWindow, QWidget {
-    background-color: #18191A;
-    color: #F5F6FA;
-    font-family: 'Segoe UI', Arial, sans-serif;
-    font-size: 15px;
-}
-QMenuBar, QMenu {
-    background-color: #242526;
-    color: #F5F6FA;
-}
-QMenuBar::item:selected, QMenu::item:selected {
-    background: #3A86FF;
-    color: white;
-}
-QTabWidget::pane {
-    border: 1px solid #3A3B3C;
-    border-radius: 8px;
-    background: #18191A;
-}
-QTabBar::tab {
-    background: #242526;
-    color: #F5F6FA;
-    border-radius: 8px;
-    padding: 8px 20px;
-    margin: 2px;
-}
-QTabBar::tab:selected {
-    background: #3A86FF;
-    color: white;
-}
-QPushButton {
-    background-color: #3A86FF;
-    color: white;
-    border: none;
-    border-radius: 8px;
-    padding: 8px 0px;
-    font-size: 15px;
-}
-QPushButton:hover {
-    background-color: #265DAB;
-}
-QLineEdit, QComboBox, QSpinBox {
-    background: #242526;
-    color: #F5F6FA;
-    border: 1px solid #3A3B3C;
-    border-radius: 8px;
-    padding: 6px 10px;
-    font-size: 15px;
-}
-QStatusBar {
-    background: #242526;
-    color: #F5F6FA;
-    border-top: 1px solid #3A3B3C;
-}
-"""
 
 class AlquilerApp:
     def __init__(self):

--- a/src/styles.py
+++ b/src/styles.py
@@ -1,0 +1,67 @@
+# Shared styling constants for Qt and CustomTkinter views
+
+# Base colors
+BG_DARK = "#18191A"
+BG_DARK_SECONDARY = "#242526"
+ENTRY_BG = "#23272F"
+TEXT_COLOR = "#F5F6FA"
+PRIMARY_COLOR = "#3A86FF"
+PRIMARY_COLOR_DARK = "#265DAB"
+BORDER_COLOR = "#3A3B3C"
+
+# Qt style sheet built from the above colors
+MODERN_QSS = f"""
+QMainWindow, QWidget {{
+    background-color: {BG_DARK};
+    color: {TEXT_COLOR};
+    font-family: 'Segoe UI', Arial, sans-serif;
+    font-size: 15px;
+}}
+QMenuBar, QMenu {{
+    background-color: {BG_DARK_SECONDARY};
+    color: {TEXT_COLOR};
+}}
+QMenuBar::item:selected, QMenu::item:selected {{
+    background: {PRIMARY_COLOR};
+    color: white;
+}}
+QTabWidget::pane {{
+    border: 1px solid {BORDER_COLOR};
+    border-radius: 8px;
+    background: {BG_DARK};
+}}
+QTabBar::tab {{
+    background: {BG_DARK_SECONDARY};
+    color: {TEXT_COLOR};
+    border-radius: 8px;
+    padding: 8px 20px;
+    margin: 2px;
+}}
+QTabBar::tab:selected {{
+    background: {PRIMARY_COLOR};
+    color: white;
+}}
+QPushButton {{
+    background-color: {PRIMARY_COLOR};
+    color: white;
+    border: none;
+    border-radius: 8px;
+    padding: 8px 0px;
+    font-size: 15px;
+}}
+QPushButton:hover {{
+    background-color: {PRIMARY_COLOR_DARK};
+}}
+QLineEdit, QTextEdit, QComboBox, QSpinBox {{
+    background-color: {ENTRY_BG};
+    color: {TEXT_COLOR};
+    border: 1px solid {BORDER_COLOR};
+    border-radius: 8px;
+    padding: 6px;
+}}
+QStatusBar {{
+    background: {ENTRY_BG};
+    color: {TEXT_COLOR};
+    border-top: 1px solid {BORDER_COLOR};
+}}
+"""

--- a/src/views/ctk_views.py
+++ b/src/views/ctk_views.py
@@ -7,6 +7,7 @@ from src.services.roles import (
     cargos_permitidos_para_gerente,
     puede_ejecutar_sql_libre
 )
+from ..styles import BG_DARK, TEXT_COLOR, PRIMARY_COLOR, PRIMARY_COLOR_DARK
 
 class BaseCTKView(ctk.CTk):
     def __init__(self, user_data, db_manager, on_logout=None):
@@ -17,7 +18,7 @@ class BaseCTKView(ctk.CTk):
         self._status_label = None
         self._stop_status = False
         self.geometry("600x400")
-        self.configure(bg="#18191A")
+        self.configure(bg=BG_DARK)
         self._build_ui()
         self._update_status_label()
         self._start_status_updater()
@@ -29,11 +30,11 @@ class BaseCTKView(ctk.CTk):
 
     def _build_ui(self):
         # Frame superior con estado y cerrar sesión
-        topbar = ctk.CTkFrame(self, fg_color="#18191A")
+        topbar = ctk.CTkFrame(self, fg_color=BG_DARK)
         topbar.pack(fill="x", pady=(0,5))
-        self._status_label = ctk.CTkLabel(topbar, text="", font=("Arial", 12, "bold"), text_color="#F5F6FA")
+        self._status_label = ctk.CTkLabel(topbar, text="", font=("Arial", 12, "bold"), text_color=TEXT_COLOR)
         self._status_label.pack(side="left", padx=10, pady=8)
-        ctk.CTkButton(topbar, text="Cerrar sesión", command=self.logout, fg_color="#3A86FF", hover_color="#265DAB", width=140, height=32).pack(side="right", padx=10, pady=8)
+        ctk.CTkButton(topbar, text="Cerrar sesión", command=self.logout, fg_color=PRIMARY_COLOR, hover_color=PRIMARY_COLOR_DARK, width=140, height=32).pack(side="right", padx=10, pady=8)
         self.tabview = ctk.CTkTabview(self)
         self.tabview.pack(expand=True, fill="both")
         # Pestaña: Mis reservas
@@ -130,11 +131,11 @@ class ClienteView(BaseCTKView):
 
     def _build_ui(self):
         # Frame superior con estado y cerrar sesión
-        topbar = ctk.CTkFrame(self, fg_color="#18191A")
+        topbar = ctk.CTkFrame(self, fg_color=BG_DARK)
         topbar.pack(fill="x", pady=(0,5))
-        self._status_label = ctk.CTkLabel(topbar, text="", font=("Arial", 12, "bold"), text_color="#F5F6FA")
+        self._status_label = ctk.CTkLabel(topbar, text="", font=("Arial", 12, "bold"), text_color=TEXT_COLOR)
         self._status_label.pack(side="left", padx=10, pady=8)
-        ctk.CTkButton(topbar, text="Cerrar sesión", command=self.logout, fg_color="#3A86FF", hover_color="#265DAB", width=140, height=32).pack(side="right", padx=10, pady=8)
+        ctk.CTkButton(topbar, text="Cerrar sesión", command=self.logout, fg_color=PRIMARY_COLOR, hover_color=PRIMARY_COLOR_DARK, width=140, height=32).pack(side="right", padx=10, pady=8)
         self.tabview = ctk.CTkTabview(self)
         self.tabview.pack(expand=True, fill="both")
         # Pestaña: Mis reservas
@@ -1982,18 +1983,18 @@ class EmpleadoVentasView(BaseCTKView):
 
     def _build_ui(self):
         # Frame superior con estado y cerrar sesión
-        topbar = ctk.CTkFrame(self, fg_color="#18191A")
+        topbar = ctk.CTkFrame(self, fg_color=BG_DARK)
         topbar.pack(fill="x", pady=(0,5))
-        self._status_label = ctk.CTkLabel(topbar, text="", font=("Arial", 12, "bold"), text_color="#F5F6FA")
+        self._status_label = ctk.CTkLabel(topbar, text="", font=("Arial", 12, "bold"), text_color=TEXT_COLOR)
         self._status_label.pack(side="left", padx=10, pady=8)
-        ctk.CTkButton(topbar, text="Cerrar sesión", command=self.logout, fg_color="#3A86FF", hover_color="#265DAB", width=140, height=32).pack(side="right", padx=10, pady=8)
+        ctk.CTkButton(topbar, text="Cerrar sesión", command=self.logout, fg_color=PRIMARY_COLOR, hover_color=PRIMARY_COLOR_DARK, width=140, height=32).pack(side="right", padx=10, pady=8)
         self.tabview = ctk.CTkTabview(self)
         self.tabview.pack(expand=True, fill="both")
         self.tab_principal = self.tabview.add("Principal")
         frame = ctk.CTkFrame(self.tabview.tab("Principal"))
         frame.pack(expand=True, fill="both")
-        ctk.CTkLabel(frame, text=self._welcome_message(), text_color="#F5F6FA", font=("Arial", 20)).pack(pady=30)
-        ctk.CTkButton(frame, text="Cerrar sesión", command=self.logout, fg_color="#3A86FF", hover_color="#265DAB", width=180, height=38).pack(side="bottom", pady=(30, 20))
+        ctk.CTkLabel(frame, text=self._welcome_message(), text_color=TEXT_COLOR, font=("Arial", 20)).pack(pady=30)
+        ctk.CTkButton(frame, text="Cerrar sesión", command=self.logout, fg_color=PRIMARY_COLOR, hover_color=PRIMARY_COLOR_DARK, width=180, height=38).pack(side="bottom", pady=(30, 20))
         # Pestaña: Clientes
         self.tab_clientes = self.tabview.add("Clientes")
         self._build_tab_clientes(self.tabview.tab("Clientes"))
@@ -2615,19 +2616,19 @@ class EmpleadoCajaView(BaseCTKView):
 
     def _build_ui(self):
         # Frame superior con estado y cerrar sesión
-        topbar = ctk.CTkFrame(self, fg_color="#18191A")
+        topbar = ctk.CTkFrame(self, fg_color=BG_DARK)
         topbar.pack(fill="x", pady=(0,5))
-        self._status_label = ctk.CTkLabel(topbar, text="", font=("Arial", 12, "bold"), text_color="#F5F6FA")
+        self._status_label = ctk.CTkLabel(topbar, text="", font=("Arial", 12, "bold"), text_color=TEXT_COLOR)
         self._status_label.pack(side="left", padx=10, pady=8)
-        ctk.CTkButton(topbar, text="Cerrar sesión", command=self.logout, fg_color="#3A86FF", hover_color="#265DAB", width=140, height=32).pack(side="right", padx=10, pady=8)
+        ctk.CTkButton(topbar, text="Cerrar sesión", command=self.logout, fg_color=PRIMARY_COLOR, hover_color=PRIMARY_COLOR_DARK, width=140, height=32).pack(side="right", padx=10, pady=8)
         self.tabview = ctk.CTkTabview(self)
         self.tabview.pack(expand=True, fill="both")
         # Pestaña principal: Bienvenida y cerrar sesión
         self.tab_principal = self.tabview.add("Principal")
         frame = ctk.CTkFrame(self.tabview.tab("Principal"))
         frame.pack(expand=True, fill="both")
-        ctk.CTkLabel(frame, text=self._welcome_message(), text_color="#F5F6FA", font=("Arial", 20)).pack(pady=30)
-        ctk.CTkButton(frame, text="Cerrar sesión", command=self.logout, fg_color="#3A86FF", hover_color="#265DAB", width=180, height=38).pack(side="bottom", pady=(30, 20))
+        ctk.CTkLabel(frame, text=self._welcome_message(), text_color=TEXT_COLOR, font=("Arial", 20)).pack(pady=30)
+        ctk.CTkButton(frame, text="Cerrar sesión", command=self.logout, fg_color=PRIMARY_COLOR, hover_color=PRIMARY_COLOR_DARK, width=180, height=38).pack(side="bottom", pady=(30, 20))
         # Pestaña: Pagos
         self.tab_pagos = self.tabview.add("Pagos")
         self._build_tab_pagos(self.tabview.tab("Pagos"))
@@ -2774,19 +2775,19 @@ class EmpleadoMantenimientoView(BaseCTKView):
 
     def _build_ui(self):
         # Frame superior con estado y cerrar sesión
-        topbar = ctk.CTkFrame(self, fg_color="#18191A")
+        topbar = ctk.CTkFrame(self, fg_color=BG_DARK)
         topbar.pack(fill="x", pady=(0,5))
-        self._status_label = ctk.CTkLabel(topbar, text="", font=("Arial", 12, "bold"), text_color="#F5F6FA")
+        self._status_label = ctk.CTkLabel(topbar, text="", font=("Arial", 12, "bold"), text_color=TEXT_COLOR)
         self._status_label.pack(side="left", padx=10, pady=8)
-        ctk.CTkButton(topbar, text="Cerrar sesión", command=self.logout, fg_color="#3A86FF", hover_color="#265DAB", width=140, height=32).pack(side="right", padx=10, pady=8)
+        ctk.CTkButton(topbar, text="Cerrar sesión", command=self.logout, fg_color=PRIMARY_COLOR, hover_color=PRIMARY_COLOR_DARK, width=140, height=32).pack(side="right", padx=10, pady=8)
         self.tabview = ctk.CTkTabview(self)
         self.tabview.pack(expand=True, fill="both")
         # Pestaña principal: Bienvenida y cerrar sesión
         self.tab_principal = self.tabview.add("Principal")
         frame = ctk.CTkFrame(self.tabview.tab("Principal"))
         frame.pack(expand=True, fill="both")
-        ctk.CTkLabel(frame, text=self._welcome_message(), text_color="#F5F6FA", font=("Arial", 20)).pack(pady=30)
-        ctk.CTkButton(frame, text="Cerrar sesión", command=self.logout, fg_color="#3A86FF", hover_color="#265DAB", width=180, height=38).pack(side="bottom", pady=(30, 20))
+        ctk.CTkLabel(frame, text=self._welcome_message(), text_color=TEXT_COLOR, font=("Arial", 20)).pack(pady=30)
+        ctk.CTkButton(frame, text="Cerrar sesión", command=self.logout, fg_color=PRIMARY_COLOR, hover_color=PRIMARY_COLOR_DARK, width=180, height=38).pack(side="bottom", pady=(30, 20))
         # Pestaña: Vehículos
         self.tab_vehiculos = self.tabview.add("Vehículos")
         self._build_tab_vehiculos(self.tabview.tab("Vehículos"))

--- a/src/views/main_view.py
+++ b/src/views/main_view.py
@@ -5,67 +5,7 @@ import logging
 
 from ..db_manager import DBManager
 from ..auth import AuthManager
-
-# QSS moderno global (debe ser igual al de main.py)
-MODERN_QSS = """
-QMainWindow, QWidget {
-    background-color: #18191A;
-    color: #F5F6FA;
-    font-family: 'Segoe UI', Arial, sans-serif;
-    font-size: 15px;
-}
-QMenuBar, QMenu {
-    background-color: #242526;
-    color: #F5F6FA;
-}
-QMenuBar::item:selected, QMenu::item:selected {
-    background: #3A86FF;
-    color: white;
-}
-QTabWidget::pane {
-    border: 1px solid #3A3B3C;
-    border-radius: 8px;
-    background: #18191A;
-}
-QTabBar::tab {
-    background: #242526;
-    color: #F5F6FA;
-    border-radius: 8px;
-    padding: 8px 20px;
-    margin: 2px;
-}
-QTabBar::tab:selected {
-    background: #3A86FF;
-    color: white;
-}
-QPushButton {
-    background-color: #3A86FF;
-    color: white;
-    border: none;
-    border-radius: 8px;
-    padding: 8px 0px;
-    font-size: 15px;
-}
-QPushButton:hover {
-    background-color: #265DAB;
-}
-QLineEdit, QTextEdit, QComboBox, QSpinBox {
-    background-color: #23272F;
-    color: #F5F6FA;
-    border: 1px solid #3A3B3C;
-    border-radius: 8px;
-    padding: 6px;
-}
-QLabel {
-    color: #F5F6FA;
-    font-size: 15px;
-}
-QStatusBar {
-    background: #23272F;
-    color: #F5F6FA;
-    border-top: 1px solid #3A3B3C;
-}
-"""
+from ..styles import MODERN_QSS
 
 class MainView(QtWidgets.QMainWindow):
     """Main application window handling role based menus and logout."""


### PR DESCRIPTION
## Summary
- add `styles.py` with common color constants and QSS generator
- import shared styles in main and Qt/CTk views
- update button and label colors to use the constants

## Testing
- `python -m py_compile main.py src/views/main_view.py src/views/ctk_views.py src/styles.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68640b9b9c3c832b8fc75f826be472e4