### PR TITLE
Add varied rental sample data and reporting tests

### DIFF
--- a/data/inserts_prueba.sql
+++ b/data/inserts_prueba.sql
@@ -23,7 +23,10 @@ INSERT INTO Estado_alquiler (descripcion) VALUES ('Activa'), ('Finalizada');
 INSERT INTO Estado_reserva (descripcion) VALUES ('Pendiente'), ('Confirmada'), ('Cancelada');
 
 -- Sucursal y proveedor
-INSERT INTO Sucursal (nombre, direccion, telefono, gerente, id_codigo_postal) VALUES ('Sucursal Norte', 'Av 68 #100-20, Bogotá', '3209876543', 'Ana Gerente', '110111');
+INSERT INTO Sucursal (nombre, direccion, telefono, gerente, id_codigo_postal)
+VALUES
+    ('Sucursal Norte', 'Av 68 #100-20, Bogotá', '3209876543', 'Ana Gerente', '110111'),
+    ('Sucursal Sur', 'Cra 15 #50-40, Cali', '3211234567', 'Juan Gerente', '760001');
 INSERT INTO Proveedor_vehiculo (nombre, direccion, telefono, correo) VALUES ('Autocolombia', 'Calle 80 #30-15, Bogotá', '3152223344', 'ventas@autocolombia.com');
 
 -- Licencia de conducción
@@ -67,16 +70,22 @@ INSERT INTO Descuento_alquiler (descripcion, valor) VALUES
 -- Alquileres de Carlos Ramírez
 INSERT INTO Alquiler (fecha_hora_salida, valor, fecha_hora_entrada, id_vehiculo, id_cliente, id_empleado, id_sucursal, id_medio_pago, id_estado, id_seguro, id_descuento)
 VALUES
-('2024-06-01 10:00:00', 210000, '2024-06-03 10:00:00', 'ABC123', 1, 3, 1, 1, 1, 1, 1),
-('2024-06-10 09:00:00', 200000, '2024-06-11 09:00:00', 'XYZ789', 1, 4, 1, 2, 1, 2, 2);
+    ('2024-06-01 10:00:00', 210000, '2024-06-03 10:00:00', 'ABC123', 1, 3, 1, 1, 1, 1, 1),
+    ('2024-06-10 09:00:00', 200000, '2024-06-11 09:00:00', 'XYZ789', 1, 4, 1, 2, 1, 2, 2),
+    ('2024-07-05 08:00:00', 150000, '2024-07-06 08:00:00', 'ABC123', 1, 4, 1, 1, 1, 1, 2),
+    ('2024-07-12 15:00:00', 170000, '2024-07-13 15:00:00', 'XYZ789', 1, 3, 2, 2, 1, 2, 1);
 
 -- Reservas de Carlos Ramírez
 INSERT INTO Reserva_alquiler (fecha_hora, abono, saldo_pendiente, id_estado_reserva, id_alquiler)
 VALUES
-('2024-05-30 09:00:00', 100000, 110000, 1, 1),
-('2024-06-08 08:00:00', 50000, 150000, 1, 2);
+    ('2024-05-30 09:00:00', 100000, 110000, 1, 1),
+    ('2024-06-08 08:00:00', 50000, 150000, 1, 2),
+    ('2024-07-04 07:00:00', 60000, 90000, 1, 3),
+    ('2024-07-11 14:00:00', 70000, 100000, 1, 4);
 
 -- Abonos a reservas
 INSERT INTO Abono_reserva (valor, fecha_hora, id_reserva, id_medio_pago) VALUES
-(100000, '2024-05-30 10:00:00', 1, 1),
-(50000, '2024-06-08 09:00:00', 2, 2);
+    (100000, '2024-05-30 10:00:00', 1, 1),
+    (50000, '2024-06-08 09:00:00', 2, 2),
+    (60000, '2024-07-04 08:00:00', 3, 1),
+    (70000, '2024-07-11 15:00:00', 4, 2);

--- a/src/services/reports.py
+++ b/src/services/reports.py
@@ -73,7 +73,7 @@ def ventas_mensuales(db, anio: int) -> List[Tuple[int, float]]:
             "WHERE strftime('%Y', fecha_hora_salida) = ? "
             "GROUP BY mes ORDER BY mes"
         )
-        params = (anio,)
+        params = (str(anio),)
     else:
         query = (
             "SELECT MONTH(fecha_hora_salida) as mes, SUM(valor) as total "

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -21,7 +21,29 @@ def setup_db(tmp_path):
             id_cliente, id_empleado, id_sucursal, id_medio_pago, id_estado, id_seguro, id_descuento)
         VALUES
             ('2024-06-01 10:00:00', 210000, '2024-06-03 10:00:00', 'ABC123', 1, 3, 1, 1, 1, 1, 1),
-            ('2024-06-10 09:00:00', 200000, '2024-06-11 09:00:00', 'XYZ789', 1, 4, 1, 2, 1, 2, 2)
+            ('2024-06-10 09:00:00', 200000, '2024-06-11 09:00:00', 'XYZ789', 1, 4, 1, 2, 1, 2, 2),
+            ('2024-07-05 08:00:00', 150000, '2024-07-06 08:00:00', 'ABC123', 1, 4, 1, 1, 1, 1, 2),
+            ('2024-07-12 15:00:00', 170000, '2024-07-13 15:00:00', 'XYZ789', 1, 3, 2, 2, 1, 2, 1)
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO Reserva_alquiler (fecha_hora, abono, saldo_pendiente, id_estado_reserva, id_alquiler)
+        VALUES
+            ('2024-05-30 09:00:00', 100000, 110000, 1, 1),
+            ('2024-06-08 08:00:00', 50000, 150000, 1, 2),
+            ('2024-07-04 07:00:00', 60000, 90000, 1, 3),
+            ('2024-07-11 14:00:00', 70000, 100000, 1, 4)
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO Abono_reserva (valor, fecha_hora, id_reserva, id_medio_pago)
+        VALUES
+            (100000, '2024-05-30 10:00:00', 1, 1),
+            (50000, '2024-06-08 09:00:00', 2, 2),
+            (60000, '2024-07-04 08:00:00', 3, 1),
+            (70000, '2024-07-11 15:00:00', 4, 2)
         """
     )
     conn.commit()
@@ -31,11 +53,22 @@ def setup_db(tmp_path):
 
 def test_ventas_por_sucursal(tmp_path):
     db = setup_db(tmp_path)
-    rows = reports.ventas_por_sucursal(db, 6, 2024)
-    assert rows == [(1, 410000.0)]
+    assert reports.ventas_por_sucursal(db, 6, 2024) == [(1, 410000.0)]
+    rows = sorted(reports.ventas_por_sucursal(db, 7, 2024))
+    assert rows == [(1, 150000.0), (2, 170000.0)]
 
 
 def test_ventas_por_vendedor(tmp_path):
     db = setup_db(tmp_path)
-    rows = sorted(reports.ventas_por_vendedor(db, 6, 2024))
-    assert rows == [(3, 210000.0), (4, 200000.0)]
+    assert sorted(reports.ventas_por_vendedor(db, 6, 2024)) == [
+        (3, 210000.0),
+        (4, 200000.0),
+    ]
+    rows = sorted(reports.ventas_por_vendedor(db, 7, 2024))
+    assert rows == [(3, 170000.0), (4, 150000.0)]
+
+
+def test_ventas_mensuales(tmp_path):
+    db = setup_db(tmp_path)
+    rows = reports.ventas_mensuales(db, 2024)
+    assert rows == [(6, 410000.0), (7, 320000.0)]


### PR DESCRIPTION
## Summary
- extend sample inserts with additional sucursales and new months of Alquileres
- ensure Abono_reserva and Reserva_alquiler cover July transactions
- fix ventas_mensuales to use string year for SQLite
- expand report tests to cover two months and new sellers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68642a203288832b89f317b667f56fbe