### PR TITLE
Add remote DB port setting and clean env sample

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
 DB_REMOTE_HOST=localhost
+DB_REMOTE_PORT=3306
 DB_REMOTE_USER=root
 DB_REMOTE_PASSWORD=contraseña
 DB_REMOTE_NAME=alquiler_vehiculos
 LOCAL_DB_PATH=data/local.sqlite
-
-API_BASE_URL=


### PR DESCRIPTION
## Summary
- update `.env.example` with `DB_REMOTE_PORT` and remove unused `API_BASE_URL`
- keep README environment instructions consistent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686498d4ec9c832ba9ffbceaeceaacec