### PR TITLE
Add SQL Libre tab for admin

### DIFF
--- a/src/views/ctk_views.py
+++ b/src/views/ctk_views.py
@@ -3482,6 +3482,10 @@ class AdminView(BaseCTKView):
         self.tab_cambiar = self.tabview.add("Cambiar contraseña")
         self._build_cambiar_contrasena_tab(self.tabview.tab("Cambiar contraseña"))
 
+        if puede_ejecutar_sql_libre(self.user_data.get('rol')):
+            self.tab_sql_libre = self.tabview.add("SQL Libre")
+            self._build_tab_sql_libre(self.tabview.tab("SQL Libre"))
+
     def _build_tab_personal(self, parent):
         import tkinter as tk
 


### PR DESCRIPTION
## Summary
- allow admins to access SQL Libre tab in CTk view

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68656043fd6c832ba6d2a2ce6652d3bc