### PR TITLE
Branch-aware queries for employees

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -63,7 +63,7 @@ class AuthManager:
             # Consulta para SQLite
             query = """
             SELECT u.id_usuario, u.usuario, r.nombre as rol,
-                   u.id_cliente, u.id_empleado, e.cargo
+                   u.id_cliente, u.id_empleado, e.cargo, e.id_sucursal
             FROM Usuario u
             JOIN Rol r ON u.id_rol = r.id_rol
             LEFT JOIN Empleado e ON u.id_empleado = e.id_empleado
@@ -73,7 +73,7 @@ class AuthManager:
             # Consulta para MySQL
             query = """
             SELECT u.id_usuario, u.usuario, r.nombre as rol,
-                   u.id_cliente, u.id_empleado, e.cargo
+                   u.id_cliente, u.id_empleado, e.cargo, e.id_sucursal
             FROM Usuario u
             JOIN Rol r ON u.id_rol = r.id_rol
             LEFT JOIN Empleado e ON u.id_empleado = e.id_empleado
@@ -98,7 +98,8 @@ class AuthManager:
                 'rol': row[2],
                 'id_cliente': row[3],
                 'id_empleado': row[4],
-                'tipo_empleado': row[5]
+                'tipo_empleado': row[5],
+                'id_sucursal': row[6]
             }
         # Credenciales incorrectas
         attempts = self.failed_attempts.get(correo, 0) + 1


### PR DESCRIPTION
## Summary
- include `id_sucursal` when authenticating users
- filter customer, reservation and vehicle lists in CTk views by the employee's branch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68656d3bab48832b9667ac5fa59131d9