### PR TITLE
Add reconnection timer with tests

### DIFF
--- a/src/views/main_view.py
+++ b/src/views/main_view.py
@@ -36,6 +36,11 @@ class MainView(QtWidgets.QMainWindow):
         self._status_timer.timeout.connect(self._update_status_bar)
         self._status_timer.start(2000)
 
+        # Intentar reconexión periódica si está offline
+        self._reconnect_timer = QTimer(self)
+        self._reconnect_timer.timeout.connect(self._attempt_reconnect)
+        self._reconnect_timer.start(5000)
+
         # Setup status bar information
         if self.statusBar():
             self.statusBar().showMessage(f"Usuario: {username} | Rol: {role}")
@@ -151,6 +156,11 @@ class MainView(QtWidgets.QMainWindow):
     def _sync_and_update_status(self):
         self._db_manager.sync_pending_reservations()
         self._update_status_bar()
+
+    def _attempt_reconnect(self):
+        """Intentar reconectar y actualizar el estado si tiene éxito."""
+        if self._db_manager.offline and self._db_manager.try_reconnect():
+            self._update_status_bar()
 
     def _cambiar_contrasena(self):
         from PyQt5.QtWidgets import QMessageBox

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+if 'dotenv' not in sys.modules:
+    sys.modules['dotenv'] = types.SimpleNamespace(load_dotenv=lambda *a, **k: None)
+
+from src.db_manager import DBManager
+
+class DummyConn:
+    def __init__(self):
+        self.autocommit = True
+    def close(self):
+        pass
+
+
+def test_eventual_reconnect(monkeypatch, tmp_path):
+    os.environ['LOCAL_DB_PATH'] = str(tmp_path / 'test.db')
+    db = DBManager()
+    assert db.offline  # comienza en modo offline por falta de mysql
+
+    events = []
+    db.set_on_reconnect_callback(lambda: events.append('callback'))
+
+    monkeypatch.setattr(db, 'sync_pending_reservations', lambda: events.append('pending'))
+    monkeypatch.setattr(db, 'sync_critical_data_to_local', lambda: events.append('critical'))
+
+    import src.db_manager as db_module
+
+    def fail_connect(**kwargs):
+        raise Exception('no server')
+
+    mysql_mock = types.SimpleNamespace(connector=types.SimpleNamespace(connect=fail_connect))
+    monkeypatch.setattr(db_module, 'mysql', mysql_mock, raising=False)
+
+    assert db.try_reconnect() is False
+    assert db.offline is True
+
+    def success_connect(**kwargs):
+        return DummyConn()
+    mysql_mock.connector.connect = success_connect
+
+    assert db.try_reconnect() is True
+    assert db.offline is False
+    assert 'callback' in events
+    assert 'pending' in events and 'critical' in events


### PR DESCRIPTION
## Summary
- implement `DBManager.try_reconnect` to attempt remote reconnection and sync data
- add periodic reconnection timer in `MainView`
- test that manager reconnects when server becomes available

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68657180ecb4832b91efd0a628b7b162