### PR TITLE
Remove unused Tipo_cliente table

### DIFF
--- a/data/inserts_prueba.sql
+++ b/data/inserts_prueba.sql
@@ -4,7 +4,6 @@ INSERT INTO Rol (nombre) VALUES ('cliente'), ('empleado'), ('gerente'), ('admin'
 -- Tipos y catálogos
 INSERT INTO Tipo_entidad (descripcion) VALUES ('Persona natural'), ('Empresa');
 INSERT INTO Medio_pago (descripcion) VALUES ('Efectivo'), ('Tarjeta'), ('Transferencia');
-INSERT INTO Tipo_cliente (descripcion) VALUES ('VIP'), ('Regular');
 INSERT INTO Tipo_documento (descripcion) VALUES ('CC'), ('CE'), ('NIT');
 INSERT INTO Codigo_postal (id_codigo_postal, pais, departamento, ciudad) VALUES ('110111', 'Colombia', 'Cundinamarca', 'Bogotá'), ('760001', 'Colombia', 'Valle del Cauca', 'Cali');
 INSERT INTO Categoria_licencia (descripcion) VALUES ('B1'), ('C1');
@@ -33,7 +32,7 @@ INSERT INTO Proveedor_vehiculo (nombre, direccion, telefono, correo) VALUES ('Au
 INSERT INTO Licencia_conduccion (estado, fecha_emision, fecha_vencimiento, id_categoria) VALUES ('Vigente', '2022-01-10', '2027-01-10', 1);
 
 -- Clientes y empleados
-INSERT INTO Cliente (documento, nombre, telefono, direccion, correo, id_licencia, id_tipo_documento, id_tipo_cliente, id_codigo_postal) VALUES ('987654321', 'Carlos Ramírez', '3111111111', 'Calle 12 #34-56, Bogotá', 'carlos.ramirez@email.com', 1, 1, 2, '110111');
+INSERT INTO Cliente (documento, nombre, telefono, direccion, correo, id_licencia, id_tipo_documento, id_codigo_postal) VALUES ('987654321', 'Carlos Ramírez', '3111111111', 'Calle 12 #34-56, Bogotá', 'carlos.ramirez@email.com', 1, 1, '110111');
 
 -- Tipos de empleado (jerarquía)
 INSERT INTO Tipo_empleado (descripcion) VALUES ('admin'), ('gerente'), ('ventas'), ('caja'), ('mantenimiento');

--- a/data/sql_bases.sql
+++ b/data/sql_bases.sql
@@ -11,10 +11,6 @@ CREATE TABLE Medio_pago (
   descripcion       VARCHAR(100) NOT NULL
 ) ENGINE=InnoDB;
 
-CREATE TABLE Tipo_cliente (
-  id_tipo           INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-  descripcion       VARCHAR(100) NOT NULL
-) ENGINE=InnoDB;
 
 CREATE TABLE Tipo_documento (
   id_tipo_documento INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
@@ -146,15 +142,12 @@ CREATE TABLE Cliente (
   infracciones      INT DEFAULT 0,
   id_licencia       INT UNSIGNED,
   id_tipo_documento INT UNSIGNED,
-  id_tipo_cliente   INT UNSIGNED,
   id_codigo_postal  VARCHAR(50),
   id_cuenta         INT UNSIGNED,
   FOREIGN KEY (id_licencia)
     REFERENCES Licencia_conduccion(id_licencia),
   FOREIGN KEY (id_tipo_documento)
     REFERENCES Tipo_documento(id_tipo_documento),
-  FOREIGN KEY (id_tipo_cliente)
-    REFERENCES Tipo_cliente(id_tipo),
   FOREIGN KEY (id_codigo_postal)
     REFERENCES Codigo_postal(id_codigo_postal)
 ) ENGINE=InnoDB;

--- a/data/sqlite_schema.sql
+++ b/data/sqlite_schema.sql
@@ -138,11 +138,6 @@ CREATE TABLE IF NOT EXISTS Codigo_postal (
     ciudad TEXT
 );
 
-CREATE TABLE IF NOT EXISTS Tipo_cliente (
-    id_tipo INTEGER PRIMARY KEY,
-    descripcion TEXT
-);
-
 CREATE TABLE IF NOT EXISTS Estado_vehiculo (
     id_estado INTEGER PRIMARY KEY,
     descripcion TEXT

--- a/src/db_manager.py
+++ b/src/db_manager.py
@@ -376,7 +376,6 @@ class DBManager:
             ("Rol", ["id_rol", "nombre"], "id_rol", True),
             ("Tipo_documento", ["id_tipo_documento", "descripcion"], "id_tipo_documento", True),
             ("Codigo_postal", ["id_codigo_postal", "pais", "departamento", "ciudad"], "id_codigo_postal", False),
-            ("Tipo_cliente", ["id_tipo", "descripcion"], "id_tipo", True),
             ("Estado_vehiculo", ["id_estado", "descripcion"], "id_estado", True),
             ("Marca_vehiculo", ["id_marca", "nombre_marca"], "id_marca", True),
             ("Color_vehiculo", ["id_color", "nombre_color"], "id_color", True),

--- a/src/views/registro_ctk.py
+++ b/src/views/registro_ctk.py
@@ -117,22 +117,6 @@ class RegistroCTk(ctk.CTk):
         t = threading.Thread(target=updater, daemon=True)
         t.start()
 
-    def _get_regular_tipo(self):
-        if self.is_sqlite:
-            return None
-        row = self.db.execute_query(
-            "SELECT id_tipo FROM Tipo_cliente WHERE LOWER(descripcion)='regular' LIMIT 1"
-        )
-        if row:
-            return row[0][0]
-        self.db.execute_query(
-            "INSERT INTO Tipo_cliente (descripcion) VALUES ('regular')",
-            fetch=False,
-        )
-        row = self.db.execute_query(
-            "SELECT id_tipo FROM Tipo_cliente WHERE LOWER(descripcion)='regular' LIMIT 1"
-        )
-        return row[0][0] if row else None
 
     def registrar(self):
         documento = self.doc_entry.get().strip()
@@ -165,10 +149,9 @@ class RegistroCTk(ctk.CTk):
             if self.cod_post_var:
                 desc = self.cod_post_var.get()
                 id_codigo = next((i for i, d in self.cod_post_opts if d == desc), None)
-            id_tipo_cliente = self._get_regular_tipo()
             insert_q = (
-                "INSERT INTO Cliente (documento, nombre, telefono, direccion, correo, id_tipo_documento, id_tipo_cliente, id_codigo_postal) "
-                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s)"
+                "INSERT INTO Cliente (documento, nombre, telefono, direccion, correo, id_tipo_documento, id_codigo_postal) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s)"
             )
             params = (
                 documento,
@@ -177,7 +160,6 @@ class RegistroCTk(ctk.CTk):
                 direccion,
                 correo,
                 id_tipo_doc,
-                id_tipo_cliente,
                 id_codigo,
             )
         try:


### PR DESCRIPTION
## Summary
- drop `Tipo_cliente` table from schemas
- remove `id_tipo_cliente` column from `Cliente`
- update sample inserts
- simplify registration view without `Tipo_cliente`
- exclude `Tipo_cliente` from sync list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865977c0300832b9d44b4195c3aa9ed