### PR TITLE
Add date range columns to rental discounts

### DIFF
--- a/data/inserts_prueba.sql
+++ b/data/inserts_prueba.sql
@@ -62,9 +62,9 @@ INSERT INTO Seguro_alquiler (estado, descripcion, vencimiento, costo) VALUES
 ('Vigente', 'Seguro básico', '2025-12-31', 20000);
 
 -- Descuentos de alquiler
-INSERT INTO Descuento_alquiler (descripcion, valor) VALUES
-('Descuento 10%', 30000),
-('Sin descuento', 0);
+INSERT INTO Descuento_alquiler (descripcion, valor, fecha_inicio, fecha_fin) VALUES
+('Descuento 10%', 30000, '2024-01-01 00:00:00', '2024-12-31 23:59:59'),
+('Sin descuento', 0, '2024-01-01 00:00:00', '2030-12-31 23:59:59');
 
 -- Alquileres de Carlos Ramírez
 INSERT INTO Alquiler (fecha_hora_salida, valor, fecha_hora_entrada, id_vehiculo, id_cliente, id_empleado, id_sucursal, id_medio_pago, id_estado, id_seguro, id_descuento)

--- a/data/sql_bases.sql
+++ b/data/sql_bases.sql
@@ -224,7 +224,9 @@ CREATE TABLE Mantenimiento (
 CREATE TABLE Descuento_alquiler (
   id_descuento      INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   descripcion       VARCHAR(255),
-  valor             DECIMAL(10,2)
+  valor             DECIMAL(10,2),
+  fecha_inicio      DATETIME,
+  fecha_fin         DATETIME
 ) ENGINE=InnoDB;
 
 CREATE TABLE Estado_reserva (

--- a/data/sqlite_schema.sql
+++ b/data/sqlite_schema.sql
@@ -68,7 +68,9 @@ CREATE TABLE IF NOT EXISTS Estado_reserva (
 CREATE TABLE IF NOT EXISTS Descuento_alquiler (
     id_descuento INTEGER PRIMARY KEY AUTOINCREMENT,
     descripcion TEXT,
-    valor REAL
+    valor REAL,
+    fecha_inicio TEXT,
+    fecha_fin TEXT
 );
 
 CREATE TABLE IF NOT EXISTS Seguro_alquiler (

--- a/src/views/ctk_views.py
+++ b/src/views/ctk_views.py
@@ -186,7 +186,7 @@ class ClienteView(BaseCTKView):
     def _cargar_reservas_cliente(self, id_cliente):
         # Consulta todas las reservas del cliente, sin importar el estado
         query = '''
-            SELECT ra.id_reserva, a.fecha_hora_salida, a.fecha_hora_entrada, a.id_vehiculo, v.modelo, v.placa, a.valor, ra.saldo_pendiente, ra.abono, es.descripcion, s.descripcion, s.costo, d.descripcion, d.valor
+            SELECT ra.id_reserva, a.fecha_hora_salida, a.fecha_hora_entrada, a.id_vehiculo, v.modelo, v.placa, a.valor, ra.saldo_pendiente, ra.abono, es.descripcion, s.descripcion, s.costo, d.descripcion, d.valor, d.fecha_inicio, d.fecha_fin
             FROM Reserva_alquiler ra
             JOIN Alquiler a ON ra.id_alquiler = a.id_alquiler
             JOIN Vehiculo v ON a.id_vehiculo = v.placa
@@ -207,7 +207,24 @@ class ClienteView(BaseCTKView):
             ctk.CTkLabel(self.cards_pendientes, text="No tienes reservas registradas", font=("Arial", 12)).pack(pady=10)
             return
         for r in reservas:
-            id_reserva, salida, entrada, id_vehiculo, modelo, placa, valor, saldo, abono, estado, seguro, costo_seguro, desc, val_desc = r
+            (
+                id_reserva,
+                salida,
+                entrada,
+                id_vehiculo,
+                modelo,
+                placa,
+                valor,
+                saldo,
+                abono,
+                estado,
+                seguro,
+                costo_seguro,
+                desc,
+                val_desc,
+                fecha_inicio,
+                fecha_fin,
+            ) = r
             # Determinar estado y color
             if estado and ("pendiente" in estado.lower() or "aprob" in estado.lower()):
                 estado_str = "⏳ Pendiente"
@@ -698,7 +715,9 @@ class ClienteView(BaseCTKView):
             ctk.CTkLabel(win, text="No hay seguros disponibles", text_color="#FF5555").pack(pady=4)
         # Descuentos disponibles
         ctk.CTkLabel(win, text="Descuento:", font=("Arial", 12)).pack(pady=4)
-        descuentos = self.db_manager.execute_query("SELECT id_descuento, descripcion, valor FROM Descuento_alquiler")
+        descuentos = self.db_manager.execute_query(
+            "SELECT id_descuento, descripcion, valor, fecha_inicio, fecha_fin FROM Descuento_alquiler"
+        )
         descuento_var = tk.StringVar()
         if descuentos:
             descuento_menu = tk.OptionMenu(win, descuento_var, *[f"{d[1]} (-${d[2]})" for d in descuentos])
@@ -1273,7 +1292,9 @@ class ClienteView(BaseCTKView):
             ctk.CTkLabel(card, text="No hay seguros disponibles", text_color="#FF5555").pack(pady=4, padx=12)
         # Descuento
         ctk.CTkLabel(card, text="Descuento", font=("Arial", 12)).pack(anchor="w", pady=(10,0), padx=12)
-        descuentos = self.db_manager.execute_query("SELECT id_descuento, descripcion, valor FROM Descuento_alquiler")
+        descuentos = self.db_manager.execute_query(
+            "SELECT id_descuento, descripcion, valor, fecha_inicio, fecha_fin FROM Descuento_alquiler"
+        )
         descuento_var = tk.StringVar()
         if descuentos:
             descuento_menu = tk.OptionMenu(card, descuento_var, *[f"{d[1]} (-${d[2]})" for d in descuentos])
@@ -1722,7 +1743,9 @@ class ClienteView(BaseCTKView):
             ctk.CTkLabel(win, text="No hay seguros disponibles", text_color="#FF5555").pack(pady=4)
         # Descuentos disponibles
         ctk.CTkLabel(win, text="Descuento:", font=("Arial", 12)).pack(pady=4)
-        descuentos = self.db_manager.execute_query("SELECT id_descuento, descripcion, valor FROM Descuento_alquiler")
+        descuentos = self.db_manager.execute_query(
+            "SELECT id_descuento, descripcion, valor, fecha_inicio, fecha_fin FROM Descuento_alquiler"
+        )
         descuento_var = tk.StringVar()
         if descuentos:
             descuento_menu = tk.OptionMenu(win, descuento_var, *[f"{d[1]} (-${d[2]})" for d in descuentos])
@@ -2449,7 +2472,9 @@ class EmpleadoVentasView(BaseCTKView):
             ctk.CTkLabel(win, text="No hay seguros disponibles", text_color="#FF5555").pack(pady=4)
         # Descuentos disponibles
         ctk.CTkLabel(win, text="Descuento:", font=("Arial", 12)).pack(pady=4)
-        descuentos = self.db_manager.execute_query("SELECT id_descuento, descripcion, valor FROM Descuento_alquiler")
+        descuentos = self.db_manager.execute_query(
+            "SELECT id_descuento, descripcion, valor, fecha_inicio, fecha_fin FROM Descuento_alquiler"
+        )
         descuento_var = tk.StringVar()
         if descuentos:
             descuento_menu = tk.OptionMenu(win, descuento_var, *[f"{d[1]} (-${d[2]})" for d in descuentos])


### PR DESCRIPTION
## Summary
- extend `Descuento_alquiler` table with `fecha_inicio` and `fecha_fin`
- seed new fields in `inserts_prueba.sql`
- fetch new columns when querying discounts and reservations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865988a2f94832ba6711739aa3c3f34