### PR TITLE
Add retry queue helpers

### DIFF
--- a/data/sqlite_schema.sql
+++ b/data/sqlite_schema.sql
@@ -250,3 +250,13 @@ CREATE TABLE IF NOT EXISTS Mantenimiento (
     fecha TEXT DEFAULT (datetime('now')),
     FOREIGN KEY (placa) REFERENCES Vehiculo(placa)
 );
+
+-- Queue for failed remote operations
+CREATE TABLE IF NOT EXISTS retry_queue (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    operation TEXT,
+    table_name TEXT,
+    payload TEXT,
+    target TEXT,
+    created_at TEXT DEFAULT (datetime('now'))
+);


### PR DESCRIPTION
## Summary
- support storing failed operations in a retry table
- expose helpers in `DualDBManager` for enqueueing and retrieving retry entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a3de7c00832bb2f2e5f70af1fa1d