### PR TITLE
Add grid uniformity and propagate settings

### DIFF
--- a/src/views/ctk_views.py
+++ b/src/views/ctk_views.py
@@ -167,7 +167,7 @@ class ClienteView(BaseCTKView):
         frame = ctk.CTkFrame(parent)
         frame.pack(expand=True, fill="both", padx=10, pady=10)
         for i in range(3):
-            frame.grid_columnconfigure(i, weight=1)
+            frame.grid_columnconfigure(i, weight=1, uniform="cols")
         frame.grid_rowconfigure(1, weight=1)
 
         ctk.CTkLabel(frame, text="Mis reservas", font=("Arial", 20, "bold")).grid(row=0, column=0, columnspan=3, pady=(0,10))
@@ -175,18 +175,21 @@ class ClienteView(BaseCTKView):
         # Contenedores por estado con scroll
         self.cards_pendientes = ctk.CTkScrollableFrame(frame, fg_color="#FFF8E1")
         self.cards_pendientes.grid(row=1, column=0, sticky="nsew", padx=5, pady=5)
+        self.cards_pendientes.grid_propagate(False)
         ctk.CTkLabel(self.cards_pendientes, text="⏳ Pendientes", font=("Arial", 15, "bold"), text_color="#B8860B").pack(anchor="w", padx=10, pady=(5,0))
 
         self.cards_pagadas = ctk.CTkScrollableFrame(frame, fg_color="#E8F5E9")
         self.cards_pagadas.grid(row=1, column=1, sticky="nsew", padx=5, pady=5)
+        self.cards_pagadas.grid_propagate(False)
         ctk.CTkLabel(self.cards_pagadas, text="✅ Pagadas", font=("Arial", 15, "bold"), text_color="#388E3C").pack(anchor="w", padx=10, pady=(5,0))
 
         self.cards_vencidas = ctk.CTkScrollableFrame(frame, fg_color="#FFEBEE")
         self.cards_vencidas.grid(row=1, column=2, sticky="nsew", padx=5, pady=5)
+        self.cards_vencidas.grid_propagate(False)
         ctk.CTkLabel(self.cards_vencidas, text="❌ Vencidas/Canceladas", font=("Arial", 15, "bold"), text_color="#C62828").pack(anchor="w", padx=10, pady=(5,0))
 
         for sf in (self.cards_pendientes, self.cards_pagadas, self.cards_vencidas):
-            sf.grid_columnconfigure(0, weight=1)
+            sf.grid_columnconfigure(0, weight=1, uniform="cols")
         self._cargar_reservas_cliente(id_cliente)
 
     def _cargar_reservas_cliente(self, id_cliente):


### PR DESCRIPTION
## Summary
- unify column sizing in `_build_tab_mis_reservas`
- stop grid propagation for scrollable frames

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865ddfaddc0832b943b45c1a41573fd