### PR TITLE
Add Estado_reserva validation

### DIFF
--- a/main.py
+++ b/main.py
@@ -64,6 +64,8 @@ class AlquilerApp:
         logger.info("Inicializando AlquilerApp...")
         # Inicializar gestores
         self.db_manager = DBManager()
+        # Validar que existan los estados de reserva requeridos
+        self.db_manager.validar_estados_reserva(show_message=True)
         self.auth_manager = AuthManager(self.db_manager)
         logger.info("Gestores inicializados correctamente")
 


### PR DESCRIPTION
## Summary
- verify required reservation states are present in the database
- warn user if states are missing and optionally show a message box
- check for missing states when initializing the application

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e35cf7f0832b9aace389d473c37d