### PR TITLE
Update mis reservas layout and filter

### DIFF
--- a/src/views/ctk_views.py
+++ b/src/views/ctk_views.py
@@ -172,14 +172,17 @@ class ClienteView(BaseCTKView):
         inner.place(relx=0.5, rely=0.5, anchor="center")
         ctk.CTkLabel(inner, text="Mis reservas", font=("Arial", 20, "bold")).pack(pady=10)
         # Contenedores para cada estado
+        # Configurar distribución en tres columnas para cada estado
+        inner.grid_columnconfigure((0, 1, 2), weight=1)
+
         self.cards_pendientes = ctk.CTkFrame(inner, fg_color="#FFF8E1")  # Amarillo pastel
-        self.cards_pendientes.pack(pady=8, fill="x")
+        self.cards_pendientes.grid(row=1, column=0, sticky="nsew", padx=5, pady=8)
         ctk.CTkLabel(self.cards_pendientes, text="⏳ Pendientes", font=("Arial", 15, "bold"), text_color="#B8860B").pack(anchor="w", padx=10, pady=(5,0))
         self.cards_pagadas = ctk.CTkFrame(inner, fg_color="#E8F5E9")  # Verde pastel
-        self.cards_pagadas.pack(pady=8, fill="x")
+        self.cards_pagadas.grid(row=1, column=1, sticky="nsew", padx=5, pady=8)
         ctk.CTkLabel(self.cards_pagadas, text="✅ Pagadas", font=("Arial", 15, "bold"), text_color="#388E3C").pack(anchor="w", padx=10, pady=(5,0))
         self.cards_vencidas = ctk.CTkFrame(inner, fg_color="#FFEBEE")  # Rojo pastel
-        self.cards_vencidas.pack(pady=8, fill="x")
+        self.cards_vencidas.grid(row=1, column=2, sticky="nsew", padx=5, pady=8)
         ctk.CTkLabel(self.cards_vencidas, text="❌ Vencidas/Canceladas", font=("Arial", 15, "bold"), text_color="#C62828").pack(anchor="w", padx=10, pady=(5,0))
         self._cargar_reservas_cliente(id_cliente)
 
@@ -194,6 +197,7 @@ class ClienteView(BaseCTKView):
             LEFT JOIN Seguro_alquiler s ON a.id_seguro = s.id_seguro
             LEFT JOIN Descuento_alquiler d ON a.id_descuento = d.id_descuento
             WHERE a.id_cliente = %s
+              AND a.fecha_hora_salida >= CURRENT_TIMESTAMP
             ORDER BY a.fecha_hora_salida DESC
         '''
         params = (id_cliente,)


### PR DESCRIPTION
## Summary
- show upcoming reservations only in `_cargar_reservas_cliente`
- use grid layout for the three reservation state columns in `_build_tab_mis_reservas`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d8e15bbc832ba113858e6b2130cf