### PR TITLE
Add basic DBManager offline tests and SQLiteManager coverage

### DIFF
--- a/tests/test_db_manager_basic.py
+++ b/tests/test_db_manager_basic.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+if 'dotenv' not in sys.modules:
+    sys.modules['dotenv'] = types.SimpleNamespace(load_dotenv=lambda *a, **k: None)
+
+from src.db_manager import DBManager
+
+
+class DummyConn:
+    def __init__(self):
+        self.autocommit = True
+
+    def close(self):
+        pass
+
+    def cursor(self):
+        class C:
+            def execute(self, *a, **k):
+                pass
+
+            def fetchall(self):
+                return []
+
+            def close(self):
+                pass
+
+        return C()
+
+
+def test_goes_offline_on_connect_failure(monkeypatch, tmp_path):
+    os.environ['LOCAL_DB_PATH'] = str(tmp_path / 'local.db')
+    import src.db_manager as db_module
+
+    def fail_connect(**kwargs):
+        raise Exception('down')
+
+    mysql_mock = types.SimpleNamespace(connector=types.SimpleNamespace(connect=fail_connect))
+    monkeypatch.setattr(db_module, 'mysql', mysql_mock, raising=False)
+
+    db = db_module.DBManager()
+    assert db.offline is True
+
+
+def test_reconnect_triggers_sync(monkeypatch, tmp_path):
+    os.environ['LOCAL_DB_PATH'] = str(tmp_path / 'local.db')
+    import src.db_manager as db_module
+
+    def fail_connect(**kwargs):
+        raise Exception('down')
+
+    mysql_mock = types.SimpleNamespace(connector=types.SimpleNamespace(connect=fail_connect))
+    monkeypatch.setattr(db_module, 'mysql', mysql_mock, raising=False)
+
+    db = db_module.DBManager()
+    assert db.offline
+
+    calls = []
+
+    def success_connect(**kwargs):
+        return DummyConn()
+
+    mysql_online = types.SimpleNamespace(connector=types.SimpleNamespace(connect=success_connect))
+    monkeypatch.setattr(db_module, 'mysql', mysql_online, raising=False)
+    monkeypatch.setattr(db, 'sync_pending_reservations', lambda: calls.append('sync'))
+    monkeypatch.setattr(db, 'sync_critical_data_to_local', lambda: calls.append('critical'))
+
+    assert db.try_reconnect() is True
+    assert db.offline is False
+    assert 'sync' in calls and 'critical' in calls

--- a/tests/test_sqlite_manager.py
+++ b/tests/test_sqlite_manager.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+if 'dotenv' not in sys.modules:
+    sys.modules['dotenv'] = types.SimpleNamespace(load_dotenv=lambda *a, **k: None)
+
+from src.sqlite_manager import SQLiteManager
+
+
+def setup_db(tmp_path):
+    os.environ['LOCAL_DB_PATH'] = str(tmp_path / 'local.db')
+    return SQLiteManager()
+
+
+def test_pending_reservation_crud(tmp_path):
+    db = setup_db(tmp_path)
+    db.save_pending_reservation({
+        'fecha_hora_salida': '2024-06-01 10:00:00',
+        'fecha_hora_entrada': '2024-06-02 10:00:00',
+        'id_vehiculo': 'AAA111',
+        'id_cliente': 1,
+        'id_seguro': 1,
+        'id_estado': 1,
+    })
+    rows = db.get_pending_reservations()
+    assert len(rows) == 1
+    rid = rows[0][0]
+
+    db.delete_reservation(rid)
+    assert db.get_pending_reservations() == []
+
+
+def test_pending_abono_crud(tmp_path):
+    db = setup_db(tmp_path)
+    conn = db.connect()
+    conn.execute(
+        "INSERT INTO Abono(valor, fecha_hora, id_reserva, pendiente) VALUES (100, '2024-06-01', 1, 1)"
+    )
+    conn.commit()
+    conn.close()
+
+    rows = db.get_pending_abonos()
+    assert len(rows) == 1
+    aid = rows[0][0]
+    db.delete_abono(aid)
+    assert db.get_pending_abonos() == []
+
+
+def test_pending_password_update(tmp_path):
+    db = setup_db(tmp_path)
+    conn = db.connect()
+    conn.execute(
+        "INSERT INTO Usuario(usuario, contrasena, pendiente) VALUES ('user', 'pwd', 1)"
+    )
+    conn.commit()
+    conn.close()
+
+    assert db.get_pending_password_updates() == [('user', 'pwd')]
+    db.clear_pending_password('user')
+    assert db.get_pending_password_updates() == []


### PR DESCRIPTION
## Summary
- add tests for SQLiteManager CRUD helpers
- add tests to ensure DBManager switches offline and syncs on reconnect

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e07c03f4832bba58c64ca57d9979