### PR TITLE
Update vehicle reservation button logic

### DIFF
--- a/src/views/ctk_views.py
+++ b/src/views/ctk_views.py
@@ -2395,17 +2395,19 @@ class EmpleadoVentasView(BaseCTKView):
                     ctk.CTkLabel(row4, text=f"📞 {sucursal_tel}", 
                                 font=("Arial", 10), text_color="#666666").pack(anchor="w", padx=5)
             
-            # Botón de reservar
+            # Botón de reservar (solo para empleados de ventas)
             btn_frame = ctk.CTkFrame(card, fg_color="transparent")
             btn_frame.pack(fill="x", padx=10, pady=(5, 10))
-            
-            ctk.CTkButton(btn_frame, text="🚗 Reservar este vehículo", 
-                         command=lambda p=placa: self._abrir_nueva_reserva_vehiculo(p),
-                         fg_color="#4CAF50", hover_color="#388E3C", 
-                         font=("Arial", 12, "bold")).pack(pady=5)
-        
 
-
+            if (self.user_data.get("tipo_empleado") or "").lower() == "ventas":
+                ctk.CTkButton(
+                    btn_frame,
+                    text="🚗 Reservar este vehículo",
+                    command=lambda p=placa: self._abrir_nueva_reserva_vehiculo(p),
+                    fg_color="#4CAF50",
+                    hover_color="#388E3C",
+                    font=("Arial", 12, "bold"),
+                ).pack(pady=5)
     def _abrir_nueva_reserva_vehiculo(self, vehiculo):
         import tkinter as tk
         from tkinter import messagebox


### PR DESCRIPTION
## Summary
- hide the "Reservar este vehículo" button for employees unless their `tipo_empleado` is `ventas`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867105ac474832b87043829e6410c7c