### PR TITLE
Fix Tk loop handling in registration

### DIFF
--- a/src/views/login_view.py
+++ b/src/views/login_view.py
@@ -182,7 +182,7 @@ class LoginView(QDialog):
 
             def volver_a_login(correo_registrado=None):
                 if hasattr(self, '_registro_window'):
-                    self._registro_window.withdraw()  # Ocultar en lugar de destruir
+                    self._registro_window.destroy()  # Cerrar completamente para detener el loop de Tk
                     self._registro_window._stop_status = True
                 self.show()
                 self.raise_()

--- a/src/views/registro_ctk.py
+++ b/src/views/registro_ctk.py
@@ -148,7 +148,7 @@ class RegistroCTk(ctk.CTk):
     def volver(self):
         if self.on_back:
             self._stop_status = True
-            self.withdraw()
+            self.destroy()
             correo_registrado = self.correo_entry.get().strip()
             self.on_back(correo_registrado)
         else:
@@ -337,7 +337,7 @@ class RegistroCTk(ctk.CTk):
             )
             if self.on_back:
                 self._stop_status = True
-                self.withdraw()
+                self.destroy()
                 self.on_back(correo)
             else:
                 self.volver()


### PR DESCRIPTION
## Summary
- close registro CTk windows with `destroy` so Tk loops terminate
- ensure login view destroys the registration window when returning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686772562dc4832b8c39a5b6da201f98