### PR TITLE
Fix registration callback cleanup in login view

### DIFF
--- a/src/views/login_view.py
+++ b/src/views/login_view.py
@@ -181,8 +181,8 @@ class LoginView(QDialog):
             self.hide()
 
             def volver_a_login(correo_registrado=None):
-                if hasattr(self, '_registro_window'):
-                    self._registro_window.destroy()  # Cerrar completamente para detener el loop de Tk
+                if getattr(self, "_registro_window", None) and self._registro_window.winfo_exists():
+                    self._registro_window.destroy()
                     self._registro_window._stop_status = True
                 self.show()
                 self.raise_()


### PR DESCRIPTION
## Summary
- fix logic when closing registration window in `open_registration`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686776f9dd38832bb7447b95f247b04c