### PR TITLE
Handle RegistroCTk window close correctly

### DIFF
--- a/src/views/registro_ctk.py
+++ b/src/views/registro_ctk.py
@@ -18,6 +18,8 @@ class RegistroCTk(ctk.CTk):
         self.correo_inicial = correo_inicial
         self.title("Registro de cliente")
         self.geometry("400x500")
+        if self.on_back:
+            self.protocol("WM_DELETE_WINDOW", self.volver)
         self._status_label = None
         self._stop_status = False
         self.is_sqlite = getattr(self.db, "offline", False)


### PR DESCRIPTION
## Summary
- ensure closing `RegistroCTk` window triggers `volver`

## Testing
- `pytest -q`
- `python test_db_connection.py`

------
https://chatgpt.com/codex/tasks/task_e_68677b0ca0f8832b9b10012bf214b949