### PR TITLE
Use DualDBManager across app

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ except Exception as e:
 # --- IMPORTS PyQt5 y módulos dependientes ---
 from PyQt5.QtWidgets import QApplication, QDialog, QMessageBox
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), 'src')))
-from src.db_manager import DBManager
+from src.dual_db_manager import DualDBManager
 from src.auth import AuthManager
 from src.views.login_view import LoginView
 from src.views.ctk_views import (
@@ -63,7 +63,7 @@ class AlquilerApp:
     def __init__(self):
         logger.info("Inicializando AlquilerApp...")
         # Inicializar gestores
-        self.db_manager = DBManager()
+        self.db_manager = DualDBManager()
         if hasattr(self.db_manager, "start_worker"):
             # Iniciar hilo de sincronización en segundo plano si está disponible
             self.db_manager.start_worker()

--- a/src/views/main_view.py
+++ b/src/views/main_view.py
@@ -3,7 +3,7 @@ from PyQt5 import QtWidgets, uic
 from PyQt5.QtCore import pyqtSignal, QTimer
 import logging
 
-from ..db_manager import DBManager
+from ..dual_db_manager import DualDBManager
 from ..auth import AuthManager
 from ..styles import MODERN_QSS
 
@@ -23,7 +23,7 @@ class MainView(QtWidgets.QMainWindow):
 
         self._username = username
         self._role = role
-        self._db_manager = db_manager if db_manager is not None else DBManager()
+        self._db_manager = db_manager if db_manager is not None else DualDBManager()
         self._auth_manager = auth_manager if auth_manager is not None else AuthManager(self._db_manager)
 
         self._sync_timer = QTimer(self)

--- a/src/views/registro_ctk.py
+++ b/src/views/registro_ctk.py
@@ -5,13 +5,13 @@ from tkinter import messagebox
 import threading
 import time
 
-from ..db_manager import DBManager
+from ..dual_db_manager import DualDBManager
 
 
 class RegistroCTk(ctk.CTk):
     """Formulario de registro de clientes usando CustomTkinter."""
 
-    def __init__(self, db_manager: DBManager, on_back=None, correo_inicial=None):
+    def __init__(self, db_manager: DualDBManager, on_back=None, correo_inicial=None):
         super().__init__()
         self.db = db_manager
         self.on_back = on_back

--- a/src/views/registro_view.py
+++ b/src/views/registro_view.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 from PyQt5 import QtWidgets, uic
-from ..db_manager import DBManager
+from ..dual_db_manager import DualDBManager
 
 
 class RegistroView(QtWidgets.QDialog):
     """Formulario simple para registrar clientes."""
 
-    def __init__(self, db_manager: DBManager, parent=None):
+    def __init__(self, db_manager: DualDBManager, parent=None):
         super().__init__(parent)
         ui_path = Path(__file__).resolve().parents[2] / 'ui' / 'registro.ui'
         uic.loadUi(ui_path, self)

--- a/src/views/reserva_view.py
+++ b/src/views/reserva_view.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from PyQt5 import QtWidgets, uic
 from mysql.connector import Error
 
-from ..db_manager import DBManager
+from ..dual_db_manager import DualDBManager
 
 
 class ReservaView(QtWidgets.QWidget):
@@ -14,7 +14,7 @@ class ReservaView(QtWidgets.QWidget):
         uic.loadUi(ui_path, self)
 
         self.client_id = client_id
-        self.db_manager = DBManager()
+        self.db_manager = DualDBManager()
 
         # Widgets
         self.vehicle_combo = self.findChild(QtWidgets.QComboBox, 'vehicleComboBox')

--- a/test_db_connection.py
+++ b/test_db_connection.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
 if 'dotenv' not in sys.modules:
     sys.modules['dotenv'] = types.SimpleNamespace(load_dotenv=lambda *a, **k: None)
 
-from src.db_manager import DBManager
+from src.dual_db_manager import DualDBManager
 from src.auth import AuthManager
 
 def test_database_connection():
@@ -23,7 +23,7 @@ def test_database_connection():
     
     try:
         # Crear instancia del gestor de base de datos
-        db_manager = DBManager()
+        db_manager = DualDBManager()
         
         # Verificar si está en modo offline
         is_offline = db_manager.is_sqlite()
@@ -122,7 +122,7 @@ def test_schema_compatibility():
     print("\n=== PRUEBA DE COMPATIBILIDAD DE ESQUEMA ===")
     
     try:
-        db_manager = DBManager()
+        db_manager = DualDBManager()
         
         # Consultas principales que deben funcionar
         consultas_prueba = [

--- a/tests/test_registro_ctk.py
+++ b/tests/test_registro_ctk.py
@@ -5,11 +5,11 @@ try:  # Skip tests if customtkinter is not available
 except Exception:  # pragma: no cover - dependency missing
     pytest.skip("customtkinter not installed", allow_module_level=True)
 
-from src.db_manager import DBManager
+from src.dual_db_manager import DualDBManager
 from src.views.registro_ctk import RegistroCTk
 
 def test_load_options_offline():
-    db = DBManager()
+    db = DualDBManager()
     db.offline = True
     reg = RegistroCTk.__new__(RegistroCTk)
     reg.db = db


### PR DESCRIPTION
## Summary
- import and instantiate DualDBManager instead of DBManager
- add compatibility helpers to DualDBManager (`connect`, `execute_query`, etc.)
- update Qt/CTk views to use DualDBManager
- update tests to expect DualDBManager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686780a37854832b9c15f154a8c520f2