### PR TITLE
Add default vehicle state and update insert logic

### DIFF
--- a/data/sql_bases.sql
+++ b/data/sql_bases.sql
@@ -194,7 +194,7 @@ CREATE TABLE Vehiculo (
   id_transmision     INT UNSIGNED,
   id_cilindraje      INT UNSIGNED,
   id_seguro_vehiculo INT UNSIGNED,
-  id_estado_vehiculo INT UNSIGNED,
+  id_estado_vehiculo INT UNSIGNED DEFAULT 1,
   id_proveedor       INT UNSIGNED,
   id_sucursal        INT UNSIGNED,
   FOREIGN KEY (id_marca)           REFERENCES Marca_vehiculo(id_marca),

--- a/data/sqlite_schema.sql
+++ b/data/sqlite_schema.sql
@@ -171,7 +171,7 @@ CREATE TABLE IF NOT EXISTS Vehiculo (
   id_transmision INTEGER,
   id_cilindraje INTEGER,
   id_seguro_vehiculo INTEGER,
-  id_estado_vehiculo INTEGER,
+  id_estado_vehiculo INTEGER DEFAULT 1,
   id_proveedor INTEGER,
   id_sucursal INTEGER,
   FOREIGN KEY (id_marca) REFERENCES Marca_vehiculo(id_marca),

--- a/src/views/ctk_views.py
+++ b/src/views/ctk_views.py
@@ -5224,10 +5224,11 @@ class GerenteView(BaseCTKView):
         query = (
             f"INSERT INTO Vehiculo (placa, n_chasis, modelo, kilometraje, "
             f"id_marca, id_color, id_tipo_vehiculo, id_transmision, "
-            f"id_blindaje, id_seguro_vehiculo, id_proveedor, id_sucursal) "
+            f"id_blindaje, id_seguro_vehiculo, id_estado_vehiculo, "
+            f"id_proveedor, id_sucursal) "
             f"VALUES ({placeholder}, {placeholder}, {placeholder}, {placeholder}, "
             f"{placeholder}, {placeholder}, {placeholder}, {placeholder}, "
-            f"{placeholder}, {placeholder}, {placeholder}, {placeholder})"
+            f"{placeholder}, {placeholder}, {placeholder}, {placeholder}, {placeholder})"
         )
         params = (
             placa,
@@ -5240,6 +5241,7 @@ class GerenteView(BaseCTKView):
             trans,
             blindaje,
             seguro,
+            1,
             prov,
             sucursal,
         )


### PR DESCRIPTION
## Summary
- default `id_estado_vehiculo` to 1 ("Disponible") in MySQL and SQLite schemas
- include `id_estado_vehiculo` column when inserting vehicles via UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68680c836aa4832b95bd43ae4364c04e