### PR TITLE
Add vehicle state validation for reservations

### DIFF
--- a/src/views/ctk_views.py
+++ b/src/views/ctk_views.py
@@ -2728,6 +2728,13 @@ class ClienteView(BaseCTKView):
             from datetime import datetime
             from tkinter import messagebox
 
+            # Verificar disponibilidad actual del vehículo
+            estado_q = "SELECT id_estado_vehiculo FROM Vehiculo WHERE placa = %s"
+            estado = self.db_manager.execute_query(estado_q, (id_vehiculo,)) or []
+            if not estado or int(estado[0][0]) != 1:
+                messagebox.showerror("Error", "El vehículo seleccionado no está disponible")
+                return False
+
             # Calcular nuevo valor
             fecha_salida_dt = datetime.strptime(fecha_salida, "%Y-%m-%d %H:%M")
             fecha_entrada_dt = datetime.strptime(fecha_entrada, "%Y-%m-%d %H:%M")
@@ -3182,6 +3189,12 @@ class EmpleadoVentasView(BaseCTKView):
                 messagebox.showwarning("Aviso", "Complete todos los campos")
                 return
             placeholder = "%s" if not self.db_manager.offline else "?"
+            # Validar estado actual del vehículo
+            estado_q = f"SELECT id_estado_vehiculo FROM Vehiculo WHERE placa = {placeholder}"
+            estado = self.db_manager.execute_query(estado_q, (veh,)) or []
+            if not estado or int(estado[0][0]) != 1:
+                messagebox.showerror("Error", "El vehículo seleccionado no está disponible")
+                return
             try:
                 if id_reserva:
                     q = f"UPDATE Alquiler a JOIN Reserva_alquiler ra ON a.id_alquiler=ra.id_alquiler SET a.id_cliente={placeholder}, a.id_vehiculo={placeholder}, a.fecha_hora_salida={placeholder}, a.fecha_hora_entrada={placeholder} WHERE ra.id_reserva={placeholder}"

--- a/src/views/reserva_view.py
+++ b/src/views/reserva_view.py
@@ -82,6 +82,12 @@ class ReservaView(QtWidgets.QWidget):
         end = self.end_date.date().toPyDate()
         seguro = 1 if self.insurance_checkbox.isChecked() else None
         placeholder = "%s" if not self.db_manager.offline else "?"
+        # Validar estado del vehículo antes de crear la reserva
+        state_q = "SELECT id_estado_vehiculo FROM Vehiculo WHERE placa = %s"
+        estado = self.db_manager.execute_query(state_q, (vehicle,)) or []
+        if not estado or int(estado[0][0]) != 1:
+            QtWidgets.QMessageBox.warning(self, 'Aviso', 'El veh\u00edculo seleccionado no est\u00e1 disponible')
+            return
         query = (
             "INSERT INTO Alquiler "
             "(fecha_hora_salida, fecha_hora_entrada, id_vehiculo, id_cliente, id_seguro, id_estado) "

--- a/tests/test_reserva_validation.py
+++ b/tests/test_reserva_validation.py
@@ -1,0 +1,83 @@
+import pytest
+
+try:  # Skip if GUI libs missing
+    import customtkinter  # noqa: F401
+    from PyQt5 import QtWidgets
+except Exception:  # pragma: no cover - dependency missing
+    pytest.skip("GUI libraries not installed", allow_module_level=True)
+
+from datetime import date
+
+from src.views import ctk_views
+from src.views.reserva_view import ReservaView
+
+
+class DummyDB:
+    def __init__(self, state=1):
+        self.state = state
+        self.queries = []
+
+    def execute_query(self, query, params=None, fetch=True, return_lastrowid=False):
+        self.queries.append(query)
+        if "SELECT id_estado_vehiculo" in query:
+            return [(self.state,)]
+        return []
+
+    def save_pending_reservation(self, datos):
+        self.saved = datos
+
+
+def make_dummy_date(d):
+    class D:
+        def date(self_inner):
+            class Q:
+                def toPyDate(self):
+                    return d
+            return Q()
+    return D()
+
+
+def make_dummy_combo(text):
+    class C:
+        def currentText(self):
+            return text
+    return C()
+
+
+def make_dummy_check(value=False):
+    class B:
+        def isChecked(self):
+            return value
+    return B()
+
+
+def test_create_reservation_checks_vehicle_state(monkeypatch):
+    db = DummyDB(state=2)
+    view = ReservaView.__new__(ReservaView)
+    view.db_manager = db
+    view.client_id = 5
+    view.vehicle_combo = make_dummy_combo("X")
+    view.start_date = make_dummy_date(date(2023, 1, 1))
+    view.end_date = make_dummy_date(date(2023, 1, 2))
+    view.insurance_checkbox = make_dummy_check(False)
+    view.sucursal_id = 1
+    called = {}
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", lambda *a, **k: called.setdefault("warn", True))
+    view.load_reservations = lambda: called.setdefault("load", True)
+    view.create_reservation()
+    assert "warn" in called
+    assert not any("INSERT INTO Alquiler" in q for q in db.queries)
+
+
+def test_actualizar_reserva_checks_vehicle_state(monkeypatch):
+    db = DummyDB(state=2)
+    view = ctk_views.ClienteView.__new__(ctk_views.ClienteView)
+    view.db_manager = db
+    view._cargar_reservas_cliente = lambda *_: None
+    view._cargar_reservas_pendientes = lambda *_: None
+    called = {}
+    monkeypatch.setattr(ctk_views.messagebox, "showerror", lambda *a, **k: called.setdefault("err", True))
+    ok = ctk_views.ClienteView._actualizar_reserva(view, 1, "2023-01-01 10:00", "2023-01-02 10:00", "X", None, None)
+    assert not ok
+    assert "err" in called
+    assert any("SELECT id_estado_vehiculo" in q for q in db.queries)


### PR DESCRIPTION
## Summary
- prevent creating or editing a reservation when the vehicle isn't available
- return an error if the vehicle isn't in state 1
- add unit tests for these validations

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68680fc50c30832b9b386753ce2f42b9