### PR TITLE
Add fecha_fin to Mantenimiento and update scheduling

### DIFF
--- a/data/sql_bases.sql
+++ b/data/sql_bases.sql
@@ -218,6 +218,7 @@ CREATE TABLE Mantenimiento (
   placa            VARCHAR(20),
   descripcion      VARCHAR(255),
   fecha            DATETIME DEFAULT CURRENT_TIMESTAMP,
+  fecha_fin        DATETIME,
   FOREIGN KEY (placa) REFERENCES Vehiculo(placa)
 ) ENGINE=InnoDB;
 

--- a/data/sqlite_schema.sql
+++ b/data/sqlite_schema.sql
@@ -204,6 +204,7 @@ CREATE TABLE IF NOT EXISTS Mantenimiento (
   placa TEXT,
   descripcion TEXT,
   fecha TEXT DEFAULT (datetime('now')),
+  fecha_fin TEXT,
   FOREIGN KEY (placa) REFERENCES Vehiculo(placa)
 );
 


### PR DESCRIPTION
## Summary
- add `fecha_fin` to Mantenimiento in both database schemas
- prompt for finish date when scheduling maintenance
- prevent scheduling if vehicle is already rented or under maintenance
- change vehicle status to `En Mantenimiento` once scheduled

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868112d4b80832bb9c6865b7f16be5a