### PR TITLE
Update maintenance states automatically

### DIFF
--- a/main.py
+++ b/main.py
@@ -67,6 +67,11 @@ class AlquilerApp:
         if hasattr(self.db_manager, "start_worker"):
             # Iniciar hilo de sincronización en segundo plano si está disponible
             self.db_manager.start_worker()
+        if hasattr(self.db_manager, "update_maintenance_states"):
+            try:
+                self.db_manager.update_maintenance_states()
+            except Exception as exc:
+                logger.error("Error updating maintenance states: %s", exc)
         self.auth_manager = AuthManager(self.db_manager)
         logger.info("Gestores inicializados correctamente")
 

--- a/src/dual_db_manager.py
+++ b/src/dual_db_manager.py
@@ -2,6 +2,7 @@ import os
 import json
 import logging
 import threading
+import datetime
 from dotenv import load_dotenv
 
 try:
@@ -36,6 +37,16 @@ class DualDBManager:
         # the ``DB_WORKER_INTERVAL`` environment variable (minutes).
         minutes = int(os.getenv("DB_WORKER_INTERVAL", "20"))
         self._interval = minutes * 60
+
+    def update_maintenance_states(self):
+        """Release vehicles from maintenance whose end date has passed."""
+        now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        query = (
+            "UPDATE Vehiculo SET id_estado_vehiculo = 1 "
+            "WHERE id_estado_vehiculo = 3 AND placa IN "
+            "(SELECT placa FROM Mantenimiento WHERE fecha_fin <= %s)"
+        )
+        self.execute_query(query, (now,), fetch=False)
 
     # ------------------------------------------------------------------
     # Public helpers

--- a/src/views/ctk_views.py
+++ b/src/views/ctk_views.py
@@ -1692,6 +1692,8 @@ class ClienteView(BaseCTKView):
         ctk.CTkLabel(card, text="Vehículo", font=("Arial", 13, "bold")).pack(
             anchor="w", pady=(10, 0), padx=12
         )
+        if hasattr(self.db_manager, "update_maintenance_states"):
+            self.db_manager.update_maintenance_states()
         placeholder = "%s" if not self.db_manager.offline else "?"
         id_sucursal = self.user_data.get("id_sucursal")
         query = (
@@ -2148,6 +2150,8 @@ class ClienteView(BaseCTKView):
         self.cards_vehiculos = ctk.CTkFrame(scrollable_frame, fg_color="#E3F2FD")
         self.cards_vehiculos.pack(fill="both", expand=True, padx=10, pady=10)
         # Listar vehículos disponibles con TODA la información relevante
+        if hasattr(self.db_manager, "update_maintenance_states"):
+            self.db_manager.update_maintenance_states()
         placeholder = "%s" if not self.db_manager.offline else "?"
         id_sucursal = self.user_data.get("id_sucursal")
         query = f"""
@@ -3134,6 +3138,8 @@ class EmpleadoVentasView(BaseCTKView):
         opt_cliente.pack(pady=4)
 
         # Vehículos disponibles
+        if hasattr(self.db_manager, "update_maintenance_states"):
+            self.db_manager.update_maintenance_states()
         placeholder = "%s" if not self.db_manager.offline else "?"
         vehiculos = (
             self.db_manager.execute_query(
@@ -3249,6 +3255,8 @@ class EmpleadoVentasView(BaseCTKView):
         self.cards_vehiculos = ctk.CTkFrame(frame, fg_color="#E3F2FD")  # Azul pastel
         self.cards_vehiculos.pack(fill="both", expand=True, padx=10, pady=10)
         # Listar vehículos disponibles con TODA la información relevante
+        if hasattr(self.db_manager, "update_maintenance_states"):
+            self.db_manager.update_maintenance_states()
         placeholder = "%s" if not self.db_manager.offline else "?"
         id_sucursal = self.user_data.get("id_sucursal")
         query = f"""

--- a/src/views/reserva_view.py
+++ b/src/views/reserva_view.py
@@ -36,6 +36,8 @@ class ReservaView(QtWidgets.QWidget):
     def load_vehicles(self):
         """Load available vehicles into the combo box."""
         try:
+            if hasattr(self.db_manager, "update_maintenance_states"):
+                self.db_manager.update_maintenance_states()
             conn = self.db_manager.connect()
             cursor = conn.cursor()
             cursor.execute(


### PR DESCRIPTION
## Summary
- update vehicle states after maintenance via `update_maintenance_states`
- run maintenance update on startup
- refresh maintenance states whenever listing available vehicles

## Testing
- `PYTHONPATH=$PWD pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686813435410832ba690dcd3c93b03b7