### PR TITLE
Add backup manager unit tests

### DIFF
--- a/tests/test_backup_manager.py
+++ b/tests/test_backup_manager.py
@@ -1,105 +1,85 @@
 import os
-import builtins
+import re
+import sqlite3
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
 
 from src.backup_manager import BackupManager
 
 
-def test_backup_on_startup_ok(monkeypatch, tmp_path):
-    db_path = tmp_path / "db.sqlite"
-    db_path.write_text("data")
-    backup_dir = tmp_path / "backups"
-    mgr = BackupManager(db_path=db_path, backup_dir=backup_dir)
-
-    monkeypatch.setattr(mgr, "verify_database_integrity", lambda: True)
-    called = {}
-    def fake_create(bt):
-        called["backup"] = bt
-        return "bk"
-    monkeypatch.setattr(mgr, "create_backup", fake_create)
-
-    result = mgr.backup_on_startup()
-    assert result == "bk"
-    assert called["backup"] == "startup"
+def _init_db(path: Path):
+    """Create a minimal SQLite database with one table and row."""
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT)")
+    conn.execute("INSERT INTO t(name) VALUES ('demo')")
+    conn.commit()
+    conn.close()
 
 
-def test_backup_on_startup_restores(monkeypatch, tmp_path):
-    db_path = tmp_path / "db.sqlite"
-    db_path.write_text("data")
-    backup_dir = tmp_path / "backups"
-    backup_dir.mkdir()
-    b1 = backup_dir / "backup_startup_a.db"
-    b1.write_text("1")
-    os.utime(b1, (1, 1))
-    b2 = backup_dir / "backup_shutdown_b.db"
-    b2.write_text("2")
-    os.utime(b2, (2, 2))
+def test_create_backup_creates_file(monkeypatch):
+    with TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "db.sqlite"
+        _init_db(db_path)
+        backup_dir = Path(tmp) / "backups"
+        mgr = BackupManager(db_path=db_path, backup_dir=backup_dir)
+        monkeypatch.setattr(mgr, "_has_enough_space", lambda: True)
 
-    mgr = BackupManager(db_path=db_path, backup_dir=backup_dir)
-    monkeypatch.setattr(mgr, "verify_database_integrity", lambda: False)
-
-    restored = {}
-    def fake_restore(p):
-        restored["path"] = Path(p)
-    monkeypatch.setattr(mgr, "restore_from_backup", fake_restore)
-
-    monkeypatch.setattr(mgr, "create_backup", lambda t: "bk")
-
-    result = mgr.backup_on_startup()
-    assert result == "bk"
-    assert restored["path"] == b2
+        backup = mgr.create_backup("startup")
+        assert backup is not None
+        backup_path = Path(backup)
+        assert backup_path.exists()
+        assert backup_path.parent == backup_dir
+        assert re.match(r"backup_startup_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.db", backup_path.name)
 
 
-def test_backup_on_startup_creates_new_db(monkeypatch, tmp_path):
-    db_path = tmp_path / "db.sqlite"
-    backup_dir = tmp_path / "backups"
-    mgr = BackupManager(db_path=db_path, backup_dir=backup_dir)
-    monkeypatch.setattr(mgr, "verify_database_integrity", lambda: False)
-    monkeypatch.setattr(mgr, "get_latest_backup", lambda t: None)
-    monkeypatch.setattr(mgr, "restore_from_backup", lambda p: None)
-    monkeypatch.setattr(mgr, "create_backup", lambda t: "bk")
+def test_cleanup_old_backups_keeps_three():
+    with TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "db.sqlite"
+        db_path.write_text("x")
+        backup_dir = Path(tmp) / "backups"
+        backup_dir.mkdir()
+        mgr = BackupManager(db_path=db_path, backup_dir=backup_dir, max_backups=3)
 
-    assert not db_path.exists()
-    result = mgr.backup_on_startup()
-    assert result == "bk"
-    assert db_path.exists()
+        for i in range(5):
+            f = backup_dir / f"backup_startup_{i}.db"
+            f.write_text(str(i))
+            os.utime(f, (i, i))
 
-
-def test_cleanup_respects_max_backups(tmp_path):
-    db_path = tmp_path / "db.sqlite"
-    db_path.write_text("x")
-    backup_dir = tmp_path / "backups"
-    backup_dir.mkdir()
-    mgr = BackupManager(db_path=db_path, backup_dir=backup_dir, max_backups=3)
-
-    for i in range(5):
-        f = backup_dir / f"backup_startup_{i}.db"
-        f.write_text(str(i))
-        os.utime(f, (i, i))
-
-    mgr.cleanup_old_backups("startup")
-    names = {p.name for p in backup_dir.iterdir()}
-    assert len(names) == 3
-    assert names == {f"backup_startup_{i}.db" for i in [4, 3, 2]}
+        mgr.cleanup_old_backups("startup")
+        remaining = {p.name for p in backup_dir.iterdir()}
+        assert len(remaining) == 3
+        assert remaining == {f"backup_startup_{i}.db" for i in [4, 3, 2]}
 
 
-def test_cleanup_compresses_when_low_disk(monkeypatch, tmp_path):
-    db_path = tmp_path / "db.sqlite"
-    db_path.write_text("x")
-    backup_dir = tmp_path / "backups"
-    backup_dir.mkdir()
-    mgr = BackupManager(db_path=db_path, backup_dir=backup_dir, max_backups=4)
+def test_verify_database_integrity_valid_and_corrupt():
+    with TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "db.sqlite"
+        _init_db(db_path)
+        mgr = BackupManager(db_path=db_path, backup_dir=Path(tmp) / "backups")
+        assert mgr.verify_database_integrity()
 
-    for i in range(4):
-        f = backup_dir / f"backup_startup_{i}.db"
-        f.write_text(str(i))
-        os.utime(f, (i, i))
+        # corrupt the database file
+        db_path.write_bytes(b"not a sqlite db")
+        assert not mgr.verify_database_integrity()
 
-    monkeypatch.setattr(mgr, "_disk_space_low", lambda ratio=0.1: True)
-    mgr.cleanup_old_backups("startup")
 
-    assert (backup_dir / "backup_startup_0.db.gz").exists()
-    assert not (backup_dir / "backup_startup_0.db").exists()
+def test_restore_from_backup(monkeypatch):
+    with TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "db.sqlite"
+        _init_db(db_path)
+        backup_dir = Path(tmp) / "backups"
+        mgr = BackupManager(db_path=db_path, backup_dir=backup_dir)
+        monkeypatch.setattr(mgr, "_has_enough_space", lambda: True)
+        backup = mgr.create_backup("startup")
 
+        # corrupt database
+        db_path.write_bytes(b"bad")
+        assert not mgr.verify_database_integrity()
+
+        mgr.restore_from_backup(backup)
+        conn = sqlite3.connect(db_path)
+        row = conn.execute("SELECT name FROM t").fetchone()
+        conn.close()
+        assert row == ("demo",)


### PR DESCRIPTION
## Summary
- rewrite `tests/test_backup_manager.py` with fresh tests
- cover backup creation, rotation, integrity checking and restore

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868473fad0c832ba8d33a22a75cf0f5