### PR TITLE
Update status updater loops

### DIFF
--- a/src/views/ctk_views.py
+++ b/src/views/ctk_views.py
@@ -140,8 +140,11 @@ class BaseCTKView(ctk.CTk):
     def _start_status_updater(self):
         def updater():
             while not self._stop_status:
-                self._update_status_labels()
-                time.sleep(2)
+                try:
+                    self._update_status_labels()
+                    time.sleep(1)
+                except Exception:
+                    time.sleep(5)
 
         t = threading.Thread(target=updater, daemon=True)
         t.start()

--- a/src/views/registro_ctk.py
+++ b/src/views/registro_ctk.py
@@ -172,8 +172,11 @@ class RegistroCTk(ctk.CTk):
     def _start_status_updater(self):
         def updater():
             while not self._stop_status:
-                self._update_status_labels()
-                time.sleep(2)
+                try:
+                    self._update_status_labels()
+                    time.sleep(1)
+                except Exception:
+                    time.sleep(5)
         t = threading.Thread(target=updater, daemon=True)
         t.start()
 


### PR DESCRIPTION
## Summary
- improve resilience of background status threads

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68684aff0a6c832bbe3b40360dbde179