### PR TITLE
Add connection logger setup

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,20 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Connection logging setup
+# ---------------------------------------------------------------------------
+def setup_connection_logging():
+    """Configure logging for remote connection status changes."""
+    conn_logger = logging.getLogger("connection_changes")
+    conn_logger.setLevel(logging.INFO)
+    if not any(isinstance(h, logging.FileHandler) for h in conn_logger.handlers):
+        formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+        handler = logging.FileHandler("connection.log")
+        handler.setFormatter(formatter)
+        conn_logger.addHandler(handler)
+    return conn_logger
+
 # --- PRUEBA DE CONEXIÓN ANTES DE IMPORTAR PyQt5 ---
 try:
     import mysql.connector
@@ -71,6 +85,7 @@ class AlquilerApp:
             logger.error("Error running startup backup: %s", exc)
 
         # Inicializar gestores
+        setup_connection_logging()
         self.db_manager = TripleDBManager()
         if hasattr(self.db_manager, "start_worker"):
             # Iniciar hilo de sincronización en segundo plano si está disponible


### PR DESCRIPTION
## Summary
- create `setup_connection_logging` helper in `main.py`
- invoke it before constructing `TripleDBManager`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68684c048ed8832bb0bb4715ac7f8f34