### PR TITLE
Fix CTk status update interval

### DIFF
--- a/src/views/ctk_views.py
+++ b/src/views/ctk_views.py
@@ -144,7 +144,7 @@ class BaseCTKView(ctk.CTk):
                     self._update_status_labels()
                     time.sleep(1)
                 except Exception:
-                    time.sleep(5)
+                    time.sleep(1)
 
         t = threading.Thread(target=updater, daemon=True)
         t.start()

--- a/src/views/registro_ctk.py
+++ b/src/views/registro_ctk.py
@@ -176,7 +176,7 @@ class RegistroCTk(ctk.CTk):
                     self._update_status_labels()
                     time.sleep(1)
                 except Exception:
-                    time.sleep(5)
+                    time.sleep(1)
         t = threading.Thread(target=updater, daemon=True)
         t.start()
 


### PR DESCRIPTION
## Summary
- ensure CustomTkinter views sleep 1 second between label refreshes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68684de35f84832bbe3d379b4867a549