### PR TITLE
Fix offline status after pinging remotes

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,6 +87,7 @@ class AlquilerApp:
         # Inicializar gestores
         setup_connection_logging()
         self.db_manager = TripleDBManager()
+        self.db_manager.ping_remotes()
         self.offline = offline_mode or self.db_manager.offline
         if self.offline:
             logger.warning("Trabajando en modo offline")


### PR DESCRIPTION
## Summary
- ensure `AlquilerApp` pings remote databases on startup
- compute offline state only after remote status is determined

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686873103a20832bb6710f4181773b31