### PR TITLE
Add reconnection test for TripleDBManager

### DIFF
--- a/src/triple_db_manager.py
+++ b/src/triple_db_manager.py
@@ -485,6 +485,27 @@ class TripleDBManager:
         self._thread.join()
         self._thread = None
 
+    def try_reconnect(self):
+        """Attempt to reconnect to the remote databases."""
+        prev1 = self.remote1_active
+        prev2 = self.remote2_active
+
+        conn1 = self.connect_remote1()
+        if conn1:
+            conn1.close()
+
+        conn2 = self.connect_remote2()
+        if conn2:
+            conn2.close()
+
+        recovered1 = not prev1 and self.remote1_active
+        recovered2 = not prev2 and self.remote2_active
+
+        if recovered1 or recovered2:
+            self.retry_pending()
+
+        return self.remote1_active or self.remote2_active
+
     # ------------------------------------------------------------------
     # Compatibility helpers
     # ------------------------------------------------------------------

--- a/tests/test_db_connection.py
+++ b/tests/test_db_connection.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.triple_db_manager import TripleDBManager
+import src.triple_db_manager as triple_module
+
+
+class DummyConn:
+    def close(self):
+        pass
+
+
+def test_offline_and_reconnect(monkeypatch, sqlite_db_path):
+    """TripleDBManager should enter offline mode then recover."""
+
+    monkeypatch.setattr(TripleDBManager, "_start_connection_monitoring", lambda self: None)
+
+    def fail_connect(*args, **kwargs):
+        raise Exception("fail")
+
+    failing_mysql = SimpleNamespace(connector=SimpleNamespace(connect=fail_connect))
+    monkeypatch.setattr(triple_module, "mysql", failing_mysql)
+
+    manager = TripleDBManager()
+
+    assert manager.remote1_active is False
+    assert manager.remote2_active is False
+    assert manager.offline is True
+
+    def success_connect(*args, **kwargs):
+        return DummyConn()
+
+    working_mysql = SimpleNamespace(connector=SimpleNamespace(connect=success_connect))
+    monkeypatch.setattr(triple_module, "mysql", working_mysql)
+
+    assert manager.try_reconnect() is True
+    assert manager.offline is False


### PR DESCRIPTION
## Summary
- add `try_reconnect` helper to `TripleDBManager` to attempt remote reconnection
- add test covering offline detection and reconnection logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68688c9af188832b85b646346f21ef3d