### PR TITLE
Fix login hashing for clients

### DIFF
--- a/src/auth.py
+++ b/src/auth.py
@@ -54,7 +54,10 @@ class AuthManager:
             return None
 
         # Aplicar hash a la contraseña
-        hashed_pwd = hashlib.sha256(contrasena.encode()).hexdigest()
+        # MySQL genera hashes SHA2 en mayúsculas. Para mantener la
+        # compatibilidad entre SQLite y MySQL convertimos el hash a
+        # mayúsculas antes de comparar.
+        hashed_pwd = hashlib.sha256(contrasena.encode()).hexdigest().upper()
         
         # Consultar base de datos
         is_sqlite = getattr(self.db, 'offline', False)
@@ -142,8 +145,8 @@ class AuthManager:
         Permite cambiar la contraseña de un usuario, validando la actual y usando SHA-256.
         Devuelve True si se actualizó correctamente, o un mensaje de error si falló alguna validación.
         """
-        hashed_actual = hashlib.sha256(contrasena_actual.encode()).hexdigest()
-        hashed_nueva = hashlib.sha256(nueva_contrasena.encode()).hexdigest()
+        hashed_actual = hashlib.sha256(contrasena_actual.encode()).hexdigest().upper()
+        hashed_nueva = hashlib.sha256(nueva_contrasena.encode()).hexdigest().upper()
         is_sqlite = getattr(self.db, 'offline', False)
         try:
             # 1. Verificar contraseña actual

--- a/src/views/registro_ctk.py
+++ b/src/views/registro_ctk.py
@@ -318,7 +318,10 @@ class RegistroCTk(ctk.CTk):
                 if self.db.offline
                 else "INSERT INTO Usuario (usuario, contrasena, id_rol, id_cliente) VALUES (%s, %s, %s, %s)"
             )
-            hashed_doc = hashlib.sha256(documento.encode()).hexdigest()
+            # MySQL's SHA2() devuelve el hash en mayúsculas, por lo que
+            # estandarizamos la contraseña a mayúsculas para evitar
+            # problemas de comparación entre bases de datos.
+            hashed_doc = hashlib.sha256(documento.encode()).hexdigest().upper()
             usuario_params = (correo, hashed_doc, rol_id, cliente_id)
             if self.db.offline:
                 self.db.save_pending_registro(


### PR DESCRIPTION
## Summary
- normalize password hashes to uppercase when logging in or changing the password
- store new user passwords in uppercase during registration

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686892047e9c832b9b4e9bf8d1f3088a