### PR TITLE
Adjust card heights

### DIFF
--- a/src/views/client_view_qt.py
+++ b/src/views/client_view_qt.py
@@ -666,6 +666,8 @@ class ClienteViewQt(QWidget):
             card.setStyleSheet(
                 "background: #f5f5f5; border-radius: 15px; margin: 10px; padding: 10px; color: black;"
             )
+            # Limitar la altura de las tarjetas para mantener el tamaño uniforme
+            card.setMinimumHeight(280)
             card_layout = QVBoxLayout(card)
             # Header
             header = QWidget()
@@ -812,8 +814,10 @@ class ClienteViewQt(QWidget):
                     monto_minimo = float(valor_total) * 0.30 if es_primer_abono else 0
                     # Tarjeta visual
                     card = QWidget()
-                    card.setStyleSheet("background: white; border-radius: 12px; margin: 8px; padding: 8px;")
-                    card.setMinimumHeight(350)
+                    card.setStyleSheet(
+                        "background: white; border-radius: 12px; margin: 8px; padding: 8px;"
+                    )
+                    card.setMinimumHeight(280)
                     card_layout = QVBoxLayout(card)
                     l_modelo = QLabel(f"{modelo} ({placa})"); l_modelo.setStyleSheet("font-weight: bold;")
                     l_saldo = QLabel(f"Saldo pendiente: ${saldo_real:,.0f}"); l_saldo.setStyleSheet("color: #B8860B;")


### PR DESCRIPTION
## Summary
- ensure vehicle cards have consistent height in client Qt view
- reduce height for pending abono cards

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6868b3a00a98832bb2b3c3cac6ad798e